### PR TITLE
feat: establish the guided DrawMotion workspace

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,8 +3,6 @@ name: DrawMotion
 description: Une toile gestuelle guidée, précise et immédiatement compréhensible.
 ---
 
-<!-- SEED: re-run $impeccable document once there's code to capture the actual tokens and components. -->
-
 # Design System: DrawMotion
 
 ## Overview
@@ -25,28 +23,30 @@ La composition reprend la clarté de Figma, l'immédiateté d'Excalidraw et la l
 
 ## Colors
 
-Stratégie restreinte : neutres francs, toile blanche, coque presque noire et accent indigo-violet réservé aux actions, à la progression et au suivi actif. Les valeurs exactes seront résolues en OKLCH pendant le lot 2.
+Stratégie restreinte : neutres légèrement teintés vers le violet, toile blanche, coque presque noire et accent violet réservé aux actions, à la progression et au suivi actif. Les tokens canoniques vivent dans `src/styles/globals.css`.
 
 ### Primary
 
-- **Indigo de mouvement** `[à résoudre pendant l'implémentation]` : action principale, outil sélectionné, progression du tutoriel et focus.
+- **Violet de mouvement** `oklch(0.56 0.22 293)` : action principale, outil sélectionné et progression.
+- **Anneau de focus** `oklch(0.72 0.16 293)` : focus clavier contrasté sur coque sombre.
 
 ### Secondary
 
-- **Vert de suivi** `[à résoudre pendant l'implémentation]` : détection fiable et réussite.
-- **Orange d'attention** `[à résoudre pendant l'implémentation]` : cadrage imparfait et avertissements récupérables.
+- **Vert de suivi** `oklch(0.72 0.16 151)` : détection fiable et réussite.
+- **Orange d'attention** `oklch(0.80 0.15 75)` : cadrage imparfait et avertissements récupérables.
 
 ### Neutral
 
-- **Coque graphite** `[à résoudre pendant l'implémentation]` : arrière-plan et barres d'outils.
-- **Toile blanche pure** `[à résoudre pendant l'implémentation]` : surface de dessin uniquement.
-- **Encre claire** `[à résoudre pendant l'implémentation]` : texte principal sur la coque.
+- **Coque graphite** `oklch(0.16 0.012 286)` : arrière-plan et barres d'outils.
+- **Surface élevée** `oklch(0.22 0.016 286)` : panneaux flottants et rails.
+- **Toile blanche** `oklch(0.995 0.002 286)` : surface de dessin uniquement.
+- **Encre claire** `oklch(0.97 0.006 286)` : texte principal sur la coque.
 
 **The Rare Accent Rule.** L'indigo-violet ne décore jamais une surface inactive ; sa rareté indique une action ou un état réel.
 
 ## Typography
 
-**Display Font:** sans-serif technique unique `[famille à choisir pendant l'implémentation]`  
+**Display Font:** Geist Variable  
 **Body Font:** même famille sans-serif  
 **Label/Mono Font:** monospace réservé aux diagnostics de développement
 
@@ -61,6 +61,14 @@ Stratégie restreinte : neutres francs, toile blanche, coque presque noire et ac
 - **Label:** poids 500, casse naturelle et espacement normal.
 
 **The One Family Rule.** Une seule famille sans-serif porte toute l'interface ; la hiérarchie vient de la taille, du poids et de l'espace.
+
+Échelle fixe de produit : `0.75rem`, `0.875rem`, `1rem`, `1.25rem`, `1.5rem`. Le corps reste à `1rem` minimum ; les tailles inférieures sont réservées aux métadonnées et libellés courts.
+
+## Spacing and Motion
+
+L'espacement suit une base de 4 points : `0.25rem`, `0.5rem`, `0.75rem`, `1rem`, `1.5rem`, `2rem`, `3rem`. Les groupes proches utilisent 8–12 px ; les zones de travail distinctes utilisent 24–48 px.
+
+Les retours directs durent `120ms` et les transitions d'état `200ms`, avec `cubic-bezier(0.25, 1, 0.5, 1)`. La réduction de mouvement ramène toutes les transitions à un changement instantané perceptible.
 
 ## Elevation
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -351,7 +351,7 @@ PR : `feat: establish the guided DrawMotion workspace`
 Commits exacts :
 
 1. `feat(ui): define DrawMotion semantic design tokens`
-   - thème sombre `new-york` en OKLCH ;
+   - thème sombre Base Nova en OKLCH ;
    - accent violet, succès vert, avertissement orange ;
    - contraste WCAG AA ;
    - `prefers-reduced-motion` ;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "shadcn": "^4.19.0",
+    "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       shadcn:
         specifier: ^4.19.0
         version: 4.19.0(supports-color@7.2.0)(typescript@6.0.3)
+      sonner:
+        specifier: ^2.0.8
+        version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -2689,6 +2692,16 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.8:
+    resolution: {integrity: sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5757,6 +5770,13 @@ snapshots:
     dependencies:
       ip-address: 10.5.0
       smart-buffer: 4.2.0
+
+  sonner@2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
 
   source-map-js@1.2.1: {}
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,5 @@
+import { WorkspaceShell } from "@/features/workspace/workspace-shell"
+
 export function App() {
-  return (
-    <main>
-      <h1>DrawMotion</h1>
-      <p>Le dessin par le mouvement arrive bientôt.</p>
-    </main>
-  )
+  return <WorkspaceShell />
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,13 @@
+import type { PropsWithChildren } from "react"
+
+import { Toaster } from "@/components/ui/sonner"
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+export function AppProviders({ children }: PropsWithChildren) {
+  return (
+    <TooltipProvider delay={300} closeDelay={100} timeout={400}>
+      {children}
+      <Toaster position="bottom-right" />
+    </TooltipProvider>
+  )
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content bg-popover text-popover-foreground ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 ring-1 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "bg-muted/50 -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,157 @@
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "bg-popover text-popover-foreground ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 text-sm ring-1 duration-100 outline-none sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "bg-muted/50 -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  children,
+  value,
+  ...props
+}: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root
+      value={value}
+      data-slot="progress"
+      className={cn("flex flex-wrap gap-3", className)}
+      {...props}
+    >
+      {children}
+      <ProgressTrack>
+        <ProgressIndicator />
+      </ProgressTrack>
+    </ProgressPrimitive.Root>
+  )
+}
+
+function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
+  return (
+    <ProgressPrimitive.Track
+      className={cn(
+        "bg-muted relative flex h-1 w-full items-center overflow-x-hidden rounded-full",
+        className,
+      )}
+      data-slot="progress-track"
+      {...props}
+    />
+  )
+}
+
+function ProgressIndicator({
+  className,
+  ...props
+}: ProgressPrimitive.Indicator.Props) {
+  return (
+    <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
+      className={cn("bg-primary h-full transition-all", className)}
+      {...props}
+    />
+  )
+}
+
+function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props) {
+  return (
+    <ProgressPrimitive.Label
+      className={cn("text-sm font-medium", className)}
+      data-slot="progress-label"
+      {...props}
+    />
+  )
+}
+
+function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props) {
+  return (
+    <ProgressPrimitive.Value
+      className={cn(
+        "text-muted-foreground ml-auto text-sm tabular-nums",
+        className,
+      )}
+      data-slot="progress-value"
+      {...props}
+    />
+  )
+}
+
+export {
+  Progress,
+  ProgressTrack,
+  ProgressIndicator,
+  ProgressLabel,
+  ProgressValue,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,23 @@
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,52 @@
+import { Slider as SliderPrimitive } from "@base-ui/react/slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: SliderPrimitive.Root.Props) {
+  const _values = Array.isArray(value)
+    ? value
+    : Array.isArray(defaultValue)
+      ? defaultValue
+      : [min, max]
+
+  return (
+    <SliderPrimitive.Root
+      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      thumbAlignment="edge"
+      {...props}
+    >
+      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+        <SliderPrimitive.Track
+          data-slot="slider-track"
+          className="bg-muted relative grow overflow-hidden rounded-full select-none data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
+        >
+          <SliderPrimitive.Indicator
+            data-slot="slider-range"
+            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+          />
+        </SliderPrimitive.Track>
+        {Array.from({ length: _values.length }, (_, index) => (
+          <SliderPrimitive.Thumb
+            data-slot="slider-thumb"
+            key={index}
+            className="border-ring ring-ring/50 relative block size-3 shrink-0 rounded-full border bg-white transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
+          />
+        ))}
+      </SliderPrimitive.Control>
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  OctagonXIcon,
+  Loader2Icon,
+} from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="dark"
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-vertical:flex-col data-vertical:items-stretch data-[size=sm]:rounded-[min(var(--radius-md),10px)]",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,43 @@
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -1,0 +1,20 @@
+import { Hand, Video } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+
+export function CameraPreview() {
+  return (
+    <section aria-label="Aperçu caméra simulé" className="camera-preview">
+      <div className="camera-preview__viewport">
+        <Hand aria-hidden="true" className="text-muted-foreground size-16" />
+        <span className="camera-preview__landmark camera-preview__landmark--one" />
+        <span className="camera-preview__landmark camera-preview__landmark--two" />
+        <span className="camera-preview__landmark camera-preview__landmark--three" />
+      </div>
+      <Badge className="camera-preview__badge" variant="secondary">
+        <Video aria-hidden="true" data-icon="inline-start" />
+        Aperçu simulé
+      </Badge>
+    </section>
+  )
+}

--- a/src/features/onboarding/gesture-coach.tsx
+++ b/src/features/onboarding/gesture-coach.tsx
@@ -1,0 +1,65 @@
+import { Hand, Pause, ScanLine } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+
+const steps = [
+  {
+    title: "Pincez pour commencer un trait",
+    description: "Rapprochez doucement le pouce et l’index.",
+    Icon: ScanLine,
+  },
+  {
+    title: "Déplacez la main pour dessiner",
+    description: "Gardez le pincement et guidez le curseur sur la toile.",
+    Icon: Hand,
+  },
+  {
+    title: "Ouvrez la main pour faire une pause",
+    description: "Le trait s’arrête dès que vos doigts se séparent.",
+    Icon: Pause,
+  },
+] as const
+
+type GestureCoachProps = {
+  step: number
+  onStepChange: (step: number) => void
+}
+
+export function GestureCoach({ step, onStepChange }: GestureCoachProps) {
+  const current = steps[step] ?? steps[0]
+  const progress = ((step + 1) / steps.length) * 100
+
+  return (
+    <section className="gesture-coach" aria-labelledby="gesture-title">
+      <div className="gesture-coach__icon" aria-hidden="true">
+        <current.Icon />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="mb-2 flex items-center gap-2">
+          <Badge variant="outline">Étape {step + 1} sur 3</Badge>
+          <span className="text-muted-foreground text-xs">Tutoriel simulé</span>
+        </div>
+        <h2 id="gesture-title" className="text-base font-semibold">
+          {current.title}
+        </h2>
+        <p className="text-muted-foreground mt-1 max-w-[52ch] text-sm leading-relaxed">
+          {current.description}
+        </p>
+        <Progress
+          aria-label={`Progression du tutoriel : étape ${step + 1} sur 3`}
+          value={progress}
+          className="mt-3 h-1.5"
+        />
+      </div>
+      <Button
+        className="h-11"
+        variant="secondary"
+        onClick={() => onStepChange((step + 1) % steps.length)}
+      >
+        {step === steps.length - 1 ? "Recommencer" : "Étape suivante"}
+      </Button>
+    </section>
+  )
+}

--- a/src/features/toolbar/tool-button.tsx
+++ b/src/features/toolbar/tool-button.tsx
@@ -1,0 +1,48 @@
+import type { ComponentProps, ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+type ToolButtonProps = ComponentProps<typeof Button> & {
+  label: string
+  shortcut?: string
+  children: ReactNode
+}
+
+export function ToolButton({
+  label,
+  shortcut,
+  children,
+  className,
+  ...props
+}: ToolButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={label}
+            className={cn("size-11", className)}
+            size="icon-lg"
+            {...props}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <span>{label}</span>
+        {shortcut ? (
+          <kbd className="bg-background/15 rounded-sm px-1.5 py-0.5 font-mono text-xs">
+            {shortcut}
+          </kbd>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/features/toolbar/tool-rail.tsx
+++ b/src/features/toolbar/tool-rail.tsx
@@ -1,0 +1,84 @@
+import { Circle, Eraser, Minus, MousePointer2, PenLine } from "lucide-react"
+
+import { Separator } from "@/components/ui/separator"
+import { ToolButton } from "@/features/toolbar/tool-button"
+
+export type DrawingTool = "pointer" | "pen" | "eraser"
+
+type ToolRailProps = {
+  activeTool: DrawingTool
+  onToolChange: (tool: DrawingTool) => void
+}
+
+const colors = [
+  { name: "Encre", className: "text-canvas-foreground" },
+  { name: "Violet", className: "text-primary" },
+  { name: "Vert", className: "text-success" },
+  { name: "Orange", className: "text-warning" },
+]
+
+export function ToolRail({ activeTool, onToolChange }: ToolRailProps) {
+  return (
+    <aside
+      aria-label="Outils de dessin simulés"
+      className="border-border bg-shell-raised flex min-h-0 flex-col items-center gap-2 rounded-xl border py-3"
+    >
+      <ToolButton
+        label="Pointeur simulé"
+        variant={activeTool === "pointer" ? "default" : "ghost"}
+        aria-pressed={activeTool === "pointer"}
+        onClick={() => onToolChange("pointer")}
+      >
+        <MousePointer2 aria-hidden="true" />
+      </ToolButton>
+      <ToolButton
+        label="Stylo simulé"
+        shortcut="P"
+        variant={activeTool === "pen" ? "default" : "ghost"}
+        aria-pressed={activeTool === "pen"}
+        onClick={() => onToolChange("pen")}
+      >
+        <PenLine aria-hidden="true" />
+      </ToolButton>
+      <ToolButton
+        label="Gomme simulée"
+        shortcut="E"
+        variant={activeTool === "eraser" ? "default" : "ghost"}
+        aria-pressed={activeTool === "eraser"}
+        onClick={() => onToolChange("eraser")}
+      >
+        <Eraser aria-hidden="true" />
+      </ToolButton>
+
+      <Separator className="my-1 w-8" />
+
+      <ToolButton
+        label="Épaisseur — bientôt disponible"
+        variant="ghost"
+        disabled
+      >
+        <Minus aria-hidden="true" className="stroke-[3]" />
+      </ToolButton>
+
+      <div
+        className="mt-auto flex flex-col gap-2"
+        aria-label="Couleurs simulées"
+      >
+        {colors.map((color, index) => (
+          <ToolButton
+            key={color.name}
+            label={`${color.name} — sélection simulée`}
+            variant="ghost"
+            aria-pressed={index === 0}
+            disabled={index !== 0}
+          >
+            <Circle
+              aria-hidden="true"
+              className={`${color.className} fill-current stroke-current`}
+            />
+          </ToolButton>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/src/features/toolbar/top-bar.tsx
+++ b/src/features/toolbar/top-bar.tsx
@@ -1,0 +1,65 @@
+import { Download, Redo2, Undo2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { ToolButton } from "@/features/toolbar/tool-button"
+
+export function TopBar() {
+  return (
+    <header className="border-border bg-background flex h-16 items-center border-b px-4">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-lg text-sm font-semibold"
+        >
+          D
+        </span>
+        <div className="min-w-0">
+          <h1 className="truncate text-base leading-tight font-semibold">
+            DrawMotion
+          </h1>
+          <p className="text-muted-foreground truncate text-xs">
+            Toile gestuelle
+          </p>
+        </div>
+      </div>
+
+      <nav
+        aria-label="Historique du dessin"
+        className="flex items-center gap-1"
+      >
+        <ToolButton
+          label="Annuler — bientôt disponible"
+          shortcut="Ctrl Z"
+          variant="ghost"
+          disabled
+        >
+          <Undo2 aria-hidden="true" />
+        </ToolButton>
+        <ToolButton
+          label="Rétablir — bientôt disponible"
+          shortcut="Ctrl Y"
+          variant="ghost"
+          disabled
+        >
+          <Redo2 aria-hidden="true" />
+        </ToolButton>
+      </nav>
+
+      <div className="flex flex-1 items-center justify-end gap-3">
+        <Badge
+          variant="outline"
+          className="text-muted-foreground hidden lg:flex"
+        >
+          Démonstration simulée
+        </Badge>
+        <Separator orientation="vertical" className="h-6" />
+        <Button className="h-11" variant="outline" disabled>
+          <Download aria-hidden="true" data-icon="inline-start" />
+          Exporter bientôt
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { AppProviders } from "@/app/providers"
+import { WorkspaceShell } from "@/features/workspace/workspace-shell"
+
+function renderWorkspace() {
+  return render(
+    <AppProviders>
+      <WorkspaceShell />
+    </AppProviders>,
+  )
+}
+
+describe("WorkspaceShell", () => {
+  it("expose une structure et des états techniques compréhensibles", () => {
+    renderWorkspace()
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "DrawMotion" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("region", { name: "Toile de dessin vide" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("region", { name: "Aperçu caméra simulé" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Annuler — bientôt disponible" }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Exporter bientôt" }),
+    ).toBeDisabled()
+  })
+
+  it("permet de sélectionner un outil au clavier", async () => {
+    const user = userEvent.setup()
+    renderWorkspace()
+
+    const pen = screen.getByRole("button", { name: "Stylo simulé" })
+    const eraser = screen.getByRole("button", { name: "Gomme simulée" })
+
+    expect(pen).toHaveAttribute("aria-pressed", "true")
+    eraser.focus()
+    await user.keyboard("{Enter}")
+
+    expect(eraser).toHaveAttribute("aria-pressed", "true")
+    expect(pen).toHaveAttribute("aria-pressed", "false")
+    expect(
+      screen.getByText("Gomme sélectionné — simulation"),
+    ).toBeInTheDocument()
+  })
+
+  it("rend les trois étapes du tutoriel simulé accessibles", async () => {
+    const user = userEvent.setup()
+    renderWorkspace()
+
+    const nextStep = screen.getByRole("button", { name: "Étape suivante" })
+    expect(
+      screen.getByRole("progressbar", {
+        name: "Progression du tutoriel : étape 1 sur 3",
+      }),
+    ).toBeInTheDocument()
+
+    await user.click(nextStep)
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Déplacez la main pour dessiner",
+      }),
+    ).toBeInTheDocument()
+
+    await user.click(nextStep)
+    expect(
+      screen.getByRole("button", { name: "Recommencer" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("progressbar", {
+        name: "Progression du tutoriel : étape 3 sur 3",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("propose un lien d’évitement comme premier arrêt clavier", async () => {
+    const user = userEvent.setup()
+    renderWorkspace()
+
+    await user.tab()
+
+    expect(screen.getByRole("link", { name: "Aller à la toile" })).toHaveFocus()
+  })
+})

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react"
+import { CircleDotDashed } from "lucide-react"
+
+import { CameraPreview } from "@/features/camera/camera-preview"
+import { GestureCoach } from "@/features/onboarding/gesture-coach"
+import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
+import { TopBar } from "@/features/toolbar/top-bar"
+
+import "./workspace.css"
+
+const toolNames: Record<DrawingTool, string> = {
+  pointer: "Pointeur",
+  pen: "Stylo",
+  eraser: "Gomme",
+}
+
+export function WorkspaceShell() {
+  const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
+  const [coachStep, setCoachStep] = useState(0)
+
+  return (
+    <div className="workspace-shell">
+      <a className="skip-link" href="#drawing-canvas">
+        Aller à la toile
+      </a>
+      <TopBar />
+      <main className="workspace-main">
+        <ToolRail activeTool={activeTool} onToolChange={setActiveTool} />
+
+        <section
+          id="drawing-canvas"
+          tabIndex={-1}
+          aria-label="Toile de dessin vide"
+          className="drawing-stage"
+        >
+          <div className="drawing-stage__status" aria-live="polite">
+            <CircleDotDashed aria-hidden="true" />
+            {toolNames[activeTool]} sélectionné — simulation
+          </div>
+          <CameraPreview />
+          <GestureCoach step={coachStep} onStepChange={setCoachStep} />
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -1,0 +1,183 @@
+.workspace-shell {
+  display: grid;
+  grid-template-rows: 4rem minmax(0, 1fr);
+  min-width: 64rem;
+  height: 100svh;
+  background: var(--background);
+}
+
+.workspace-main {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: var(--space-lg);
+  min-height: 0;
+  padding: var(--space-lg);
+}
+
+.drawing-stage {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  color: var(--canvas-foreground);
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 1rem 3rem oklch(0.06 0.01 286 / 28%);
+}
+
+.drawing-stage:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.drawing-stage__status {
+  position: absolute;
+  top: var(--space-lg);
+  left: var(--space-lg);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 2rem;
+  padding-inline: var(--space-md);
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--shell-sunken);
+  border-radius: var(--radius-md);
+}
+
+.drawing-stage__status svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--primary);
+}
+
+.camera-preview {
+  position: absolute;
+  top: var(--space-xl);
+  right: var(--space-xl);
+  display: grid;
+  justify-items: center;
+  gap: var(--space-sm);
+}
+
+.camera-preview__viewport {
+  position: relative;
+  display: grid;
+  width: 10rem;
+  aspect-ratio: 1;
+  place-items: center;
+  overflow: hidden;
+  color: var(--foreground);
+  background: var(--shell-sunken);
+  border: 2px solid var(--border);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.25rem var(--canvas);
+}
+
+.camera-preview__badge {
+  color: var(--foreground);
+  box-shadow: 0 0.25rem 1rem oklch(0.06 0.01 286 / 18%);
+}
+
+.camera-preview__landmark {
+  position: absolute;
+  width: 0.5rem;
+  height: 0.5rem;
+  background: var(--success);
+  border: 2px solid var(--shell-sunken);
+  border-radius: 50%;
+}
+
+.camera-preview__landmark--one {
+  top: 31%;
+  left: 43%;
+}
+
+.camera-preview__landmark--two {
+  top: 47%;
+  left: 63%;
+}
+
+.camera-preview__landmark--three {
+  top: 64%;
+  left: 51%;
+}
+
+.gesture-coach {
+  position: absolute;
+  right: var(--space-2xl);
+  bottom: var(--space-2xl);
+  left: var(--space-2xl);
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+  max-width: 50rem;
+  min-height: 7.5rem;
+  padding: var(--space-lg);
+  margin-inline: auto;
+  color: var(--foreground);
+  background: var(--shell-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 1rem 2rem oklch(0.06 0.01 286 / 24%);
+}
+
+.gesture-coach__icon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  border-radius: var(--radius-lg);
+}
+
+.gesture-coach__icon svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.skip-link {
+  position: fixed;
+  top: var(--space-sm);
+  left: var(--space-sm);
+  z-index: 100;
+  padding: var(--space-sm) var(--space-md);
+  color: var(--primary-foreground);
+  background: var(--primary);
+  border-radius: var(--radius-md);
+  transform: translateY(-200%);
+  transition: transform var(--duration-fast) var(--ease-out-quart);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+@media (max-height: 48rem) {
+  .camera-preview__viewport {
+    width: 8rem;
+  }
+
+  .gesture-coach {
+    right: var(--space-lg);
+    bottom: var(--space-lg);
+    left: var(--space-lg);
+    min-height: 6rem;
+  }
+}
+
+@media (min-width: 96rem) {
+  .workspace-main {
+    grid-template-columns: 5rem minmax(0, 1fr);
+    gap: var(--space-xl);
+    padding: var(--space-xl);
+  }
+
+  .camera-preview__viewport {
+    width: 12rem;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 
 import { App } from "@/app/App"
+import { AppProviders } from "@/app/providers"
 import "@/styles/globals.css"
 
 const root = document.getElementById("root")
@@ -12,6 +13,8 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <AppProviders>
+      <App />
+    </AppProviders>
   </StrictMode>,
 )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,39 +7,49 @@
 
 :root {
   font-synthesis: none;
+  font-kerning: normal;
+  font-optical-sizing: auto;
   text-rendering: optimizeLegibility;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --background: oklch(0.16 0.012 286);
+  --foreground: oklch(0.97 0.006 286);
+  --card: oklch(0.2 0.014 286);
+  --card-foreground: oklch(0.97 0.006 286);
+  --popover: oklch(0.23 0.016 286);
+  --popover-foreground: oklch(0.97 0.006 286);
+  --primary: oklch(0.56 0.22 293);
+  --primary-foreground: oklch(0.99 0.003 286);
+  --secondary: oklch(0.25 0.018 286);
+  --secondary-foreground: oklch(0.94 0.008 286);
+  --muted: oklch(0.24 0.014 286);
+  --muted-foreground: oklch(0.74 0.014 286);
+  --accent: oklch(0.31 0.08 293);
+  --accent-foreground: oklch(0.98 0.005 286);
+  --destructive: oklch(0.63 0.21 25);
+  --border: oklch(0.34 0.018 286);
+  --input: oklch(0.3 0.018 286);
+  --ring: oklch(0.72 0.16 293);
+  --success: oklch(0.72 0.16 151);
+  --success-foreground: oklch(0.16 0.03 151);
+  --warning: oklch(0.8 0.15 75);
+  --warning-foreground: oklch(0.2 0.04 75);
+  --canvas: oklch(0.995 0.002 286);
+  --canvas-foreground: oklch(0.18 0.01 286);
+  --shell-raised: oklch(0.22 0.016 286);
+  --shell-sunken: oklch(0.125 0.01 286);
+  --radius: 0.5rem;
+
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 0.75rem;
+  --space-lg: 1rem;
+  --space-xl: 1.5rem;
+  --space-2xl: 2rem;
+  --space-3xl: 3rem;
+
+  --duration-fast: 120ms;
+  --duration-state: 200ms;
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 * {
@@ -50,6 +60,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
+  overflow: hidden;
 }
 
 button,
@@ -61,20 +72,15 @@ select {
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: "Geist Variable", sans-serif;
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
+  --font-sans: "Geist Variable", "Segoe UI", sans-serif;
+  --color-success-foreground: var(--success-foreground);
+  --color-success: var(--success);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning: var(--warning);
+  --color-canvas-foreground: var(--canvas-foreground);
+  --color-canvas: var(--canvas);
+  --color-shell-raised: var(--shell-raised);
+  --color-shell-sunken: var(--shell-sunken);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -102,40 +108,6 @@ select {
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-}
-
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -145,5 +117,16 @@ select {
   }
   html {
     @apply font-sans;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest"
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Objectif

Établir la coque guidée du lot 2 sans activer de moteur caméra, geste ou dessin réel.

## Changements

- tokens sémantiques OKLCH, Geist, rythme 4-points et réduction de mouvement
- primitives shadcn Base Nova reposant exclusivement sur Base UI
- toile dominante, rail d’outils, aperçu caméra simulé et tutoriel en trois étapes
- états désactivés ou explicitement marqués comme simulés

## Preuves

- [x] pnpm validate
- [x] 5 tests unitaires et d’accessibilité
- [x] vérification visuelle 1280x720, 1440x900 et 1920x1080
- [x] scans Impeccable layout et type sans anomalie
- [x] aucun paquet Radix installé

Captures locales générées sous test-results/visual, exclues de Git conformément à la politique du dépôt.

## Risques et rollback

Le lot expose uniquement des interactions simulées. Un revert des quatre commits rétablit le bootstrap sans migration de données.