### PR TITLE
feat: add privacy-first camera lifecycle

### DIFF
--- a/src/features/camera/camera-preview.test.tsx
+++ b/src/features/camera/camera-preview.test.tsx
@@ -1,0 +1,171 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { CameraPreview } from "@/features/camera/camera-preview"
+import type { CameraAdapter } from "@/features/camera/use-camera-lifecycle"
+import { CameraRequestError } from "@/infrastructure/camera/media-stream-adapter"
+
+function createStream(deviceId = "front") {
+  const stop = vi.fn()
+  const track = {
+    getSettings: () => ({ deviceId }),
+    stop,
+  } as unknown as MediaStreamTrack
+  const stream = {
+    getTracks: () => [track],
+    getVideoTracks: () => [track],
+  } as unknown as MediaStream
+
+  return { stop, stream }
+}
+
+function createAdapter(overrides: Partial<CameraAdapter> = {}) {
+  const activeStream = createStream()
+  const adapter: CameraAdapter = {
+    listDevices: vi.fn(() =>
+      Promise.resolve([{ id: "front", label: "Caméra avant" }]),
+    ),
+    request: vi.fn(() => Promise.resolve(activeStream.stream)),
+    stop: vi.fn(),
+    ...overrides,
+  }
+
+  return { activeStream, adapter }
+}
+
+describe("CameraPreview", () => {
+  it("explains local processing before requesting permission", () => {
+    const { adapter } = createAdapter()
+
+    render(<CameraPreview adapterFactory={() => adapter} />)
+
+    expect(
+      screen.getByText(/La vidéo reste sur cet appareil/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Activer ma caméra" }),
+    ).toBeInTheDocument()
+    expect(adapter.request).not.toHaveBeenCalled()
+  })
+
+  it("shows the local stream and lets the user pause it", async () => {
+    const user = userEvent.setup()
+    const { adapter } = createAdapter()
+
+    render(<CameraPreview adapterFactory={() => adapter} />)
+    await user.click(screen.getByRole("button", { name: "Activer ma caméra" }))
+
+    expect(await screen.findByText("Caméra active")).toBeInTheDocument()
+    expect(screen.getByLabelText("Flux vidéo local")).not.toHaveAttribute(
+      "hidden",
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Mettre la caméra en pause" }),
+    )
+
+    expect(adapter.stop).toHaveBeenCalledOnce()
+    expect(screen.getByText("Caméra en pause")).toBeInTheDocument()
+  })
+
+  it.each([
+    ["denied", "Accès caméra refusé", "Réessayer"],
+    ["missing", "Aucune caméra détectée", "Rechercher une caméra"],
+    ["busy", "Caméra déjà utilisée", "Réessayer"],
+    ["failed", "Impossible de démarrer la caméra", "Réessayer"],
+  ] as const)(
+    "renders an actionable %s recovery state",
+    async (failure, title, action) => {
+      const user = userEvent.setup()
+      const { adapter } = createAdapter({
+        request: vi.fn(() => Promise.reject(new CameraRequestError(failure))),
+      })
+
+      render(<CameraPreview adapterFactory={() => adapter} />)
+      await user.click(
+        screen.getByRole("button", { name: "Activer ma caméra" }),
+      )
+
+      expect(await screen.findByText(title)).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: action })).toBeInTheDocument()
+    },
+  )
+
+  it("recovers after a busy camera becomes available", async () => {
+    const user = userEvent.setup()
+    const { adapter, activeStream } = createAdapter()
+    vi.mocked(adapter.request)
+      .mockRejectedValueOnce(new CameraRequestError("busy"))
+      .mockResolvedValueOnce(activeStream.stream)
+
+    render(<CameraPreview adapterFactory={() => adapter} />)
+    await user.click(screen.getByRole("button", { name: "Activer ma caméra" }))
+    await user.click(await screen.findByRole("button", { name: "Réessayer" }))
+
+    expect(await screen.findByText("Caméra active")).toBeInTheDocument()
+    expect(adapter.request).toHaveBeenCalledTimes(2)
+  })
+
+  it("switches between available cameras", async () => {
+    const user = userEvent.setup()
+    const front = createStream("front")
+    const back = createStream("back")
+    const { adapter } = createAdapter({
+      listDevices: vi.fn(() =>
+        Promise.resolve([
+          { id: "front", label: "Caméra avant" },
+          { id: "back", label: "Caméra arrière" },
+        ]),
+      ),
+      request: vi
+        .fn<CameraAdapter["request"]>()
+        .mockResolvedValueOnce(front.stream)
+        .mockResolvedValueOnce(back.stream),
+    })
+
+    render(<CameraPreview adapterFactory={() => adapter} />)
+    await user.click(screen.getByRole("button", { name: "Activer ma caméra" }))
+    const selector = await screen.findByRole("combobox", {
+      name: "Caméra utilisée",
+    })
+    await user.selectOptions(selector, "back")
+
+    await waitFor(() =>
+      expect(adapter.request).toHaveBeenLastCalledWith("back"),
+    )
+    expect(await screen.findByText("Caméra active")).toBeInTheDocument()
+  })
+
+  it("stops the stream when the page becomes hidden", async () => {
+    const user = userEvent.setup()
+    const { adapter } = createAdapter()
+
+    render(<CameraPreview adapterFactory={() => adapter} />)
+    await user.click(screen.getByRole("button", { name: "Activer ma caméra" }))
+    await screen.findByText("Caméra active")
+
+    const visibility = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("hidden")
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    expect(adapter.stop).toHaveBeenCalledOnce()
+    expect(await screen.findByText("Caméra en pause")).toBeInTheDocument()
+    visibility.mockRestore()
+  })
+
+  it("stops the stream when the preview unmounts", async () => {
+    const user = userEvent.setup()
+    const { adapter } = createAdapter()
+    const view = render(<CameraPreview adapterFactory={() => adapter} />)
+    await user.click(screen.getByRole("button", { name: "Activer ma caméra" }))
+    await screen.findByText("Caméra active")
+
+    view.unmount()
+
+    expect(adapter.stop).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -1,20 +1,165 @@
-import { Hand, Video } from "lucide-react"
+import {
+  Camera,
+  CameraOff,
+  CircleAlert,
+  LoaderCircle,
+  ShieldCheck,
+  Video,
+} from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  useCameraLifecycle,
+  type CameraAdapterFactory,
+} from "@/features/camera/use-camera-lifecycle"
 
-export function CameraPreview() {
+type CameraPreviewProps = {
+  adapterFactory?: CameraAdapterFactory
+}
+
+const errorContent = {
+  denied: {
+    title: "Accès caméra refusé",
+    description:
+      "Autorisez la caméra dans les réglages du navigateur, puis réessayez.",
+    action: "Réessayer",
+  },
+  missing: {
+    title: "Aucune caméra détectée",
+    description: "Branchez une caméra, puis lancez une nouvelle recherche.",
+    action: "Rechercher une caméra",
+  },
+  busy: {
+    title: "Caméra déjà utilisée",
+    description: "Fermez l’application qui utilise la caméra, puis réessayez.",
+    action: "Réessayer",
+  },
+  failed: {
+    title: "Impossible de démarrer la caméra",
+    description: "Vérifiez votre caméra ou rechargez la page, puis réessayez.",
+    action: "Réessayer",
+  },
+} as const
+
+export function CameraPreview({ adapterFactory }: CameraPreviewProps) {
+  const {
+    devices,
+    selectedDeviceId,
+    selectDevice,
+    start,
+    state,
+    stop,
+    videoRef,
+  } = useCameraLifecycle(adapterFactory)
+  const error =
+    state === "denied" ||
+    state === "missing" ||
+    state === "busy" ||
+    state === "failed"
+      ? errorContent[state]
+      : null
+
   return (
-    <section aria-label="Aperçu caméra simulé" className="camera-preview">
+    <section aria-label="Aperçu caméra" className="camera-preview">
       <div className="camera-preview__viewport">
-        <Hand aria-hidden="true" className="text-muted-foreground size-16" />
-        <span className="camera-preview__landmark camera-preview__landmark--one" />
-        <span className="camera-preview__landmark camera-preview__landmark--two" />
-        <span className="camera-preview__landmark camera-preview__landmark--three" />
+        <video
+          ref={videoRef}
+          className="camera-preview__video"
+          aria-label="Flux vidéo local"
+          autoPlay
+          muted
+          playsInline
+          hidden={state !== "ready"}
+        />
+
+        {state === "requesting" ? (
+          <LoaderCircle aria-hidden="true" className="camera-preview__loader" />
+        ) : null}
+
+        {state === "idle" || state === "stopped" ? (
+          <Camera
+            aria-hidden="true"
+            className="text-muted-foreground size-12"
+          />
+        ) : null}
+
+        {error ? (
+          <CameraOff aria-hidden="true" className="text-warning size-12" />
+        ) : null}
       </div>
-      <Badge className="camera-preview__badge" variant="secondary">
-        <Video aria-hidden="true" data-icon="inline-start" />
-        Aperçu simulé
-      </Badge>
+
+      <div className="camera-preview__controls" aria-live="polite">
+        {state === "idle" ? (
+          <>
+            <div className="camera-preview__message">
+              <ShieldCheck aria-hidden="true" />
+              <p>
+                La vidéo reste sur cet appareil et n’est jamais enregistrée.
+              </p>
+            </div>
+            <Button className="h-11 w-full" onClick={() => void start()}>
+              <Video aria-hidden="true" data-icon="inline-start" />
+              Activer ma caméra
+            </Button>
+          </>
+        ) : null}
+
+        {state === "requesting" ? (
+          <Badge variant="secondary">Activation de la caméra…</Badge>
+        ) : null}
+
+        {state === "ready" ? (
+          <>
+            <Badge className="camera-preview__status">
+              <span aria-hidden="true" className="camera-preview__status-dot" />
+              Caméra active
+            </Badge>
+            {devices.length > 1 ? (
+              <label className="camera-preview__device-field">
+                <span>Caméra utilisée</span>
+                <select
+                  value={selectedDeviceId}
+                  onChange={(event) => selectDevice(event.target.value)}
+                >
+                  {devices.map((device) => (
+                    <option key={device.id} value={device.id}>
+                      {device.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+            <Button variant="ghost" size="sm" onClick={stop}>
+              Mettre la caméra en pause
+            </Button>
+          </>
+        ) : null}
+
+        {state === "stopped" ? (
+          <>
+            <Badge variant="secondary">Caméra en pause</Badge>
+            <Button className="h-11" onClick={() => void start()}>
+              Reprendre la caméra
+            </Button>
+          </>
+        ) : null}
+
+        {error ? (
+          <div className="camera-preview__error">
+            <div className="camera-preview__message">
+              <CircleAlert aria-hidden="true" />
+              <div>
+                <p className="font-medium">{error.title}</p>
+                <p>{error.description}</p>
+              </div>
+            </div>
+            <Button className="h-11 w-full" onClick={() => void start()}>
+              {error.action}
+            </Button>
+          </div>
+        ) : null}
+      </div>
     </section>
   )
 }

--- a/src/features/camera/camera-state.test.ts
+++ b/src/features/camera/camera-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CAMERA_STATES,
+  transitionCameraState,
+  type CameraEvent,
+  type CameraState,
+} from "@/features/camera/camera-state"
+
+type RequestResultEvent = Exclude<CameraEvent["type"], "REQUEST" | "STOP">
+
+describe("camera lifecycle", () => {
+  it("déclare les huit états contractuels", () => {
+    expect(CAMERA_STATES).toEqual([
+      "idle",
+      "requesting",
+      "ready",
+      "denied",
+      "missing",
+      "busy",
+      "failed",
+      "stopped",
+    ])
+  })
+
+  it.each([
+    ["READY", "ready"],
+    ["DENIED", "denied"],
+    ["MISSING", "missing"],
+    ["BUSY", "busy"],
+    ["FAIL", "failed"],
+  ] satisfies Array<[RequestResultEvent, CameraState]>)(
+    "résout une demande avec %s vers %s",
+    (eventType, expectedState) => {
+      expect(transitionCameraState("requesting", { type: eventType })).toBe(
+        expectedState,
+      )
+    },
+  )
+
+  it.each([
+    "denied",
+    "missing",
+    "busy",
+    "failed",
+    "stopped",
+  ] satisfies CameraState[])("permet de relancer depuis l’état %s", (state) => {
+    expect(transitionCameraState(state, { type: "REQUEST" })).toBe("requesting")
+  })
+
+  it("passe à stopped lors de l’arrêt d’un flux prêt", () => {
+    expect(transitionCameraState("ready", { type: "STOP" })).toBe("stopped")
+  })
+
+  it("ignore les résultats tardifs après un arrêt", () => {
+    expect(transitionCameraState("stopped", { type: "READY" })).toBe("stopped")
+  })
+})

--- a/src/features/camera/camera-state.ts
+++ b/src/features/camera/camera-state.ts
@@ -1,0 +1,51 @@
+export const CAMERA_STATES = [
+  "idle",
+  "requesting",
+  "ready",
+  "denied",
+  "missing",
+  "busy",
+  "failed",
+  "stopped",
+] as const
+
+export type CameraState = (typeof CAMERA_STATES)[number]
+
+export type CameraEvent =
+  | { type: "REQUEST" }
+  | { type: "READY" }
+  | { type: "DENIED" }
+  | { type: "MISSING" }
+  | { type: "BUSY" }
+  | { type: "FAIL" }
+  | { type: "STOP" }
+
+export function transitionCameraState(
+  state: CameraState,
+  event: CameraEvent,
+): CameraState {
+  if (event.type === "STOP") {
+    return state === "idle" ? "idle" : "stopped"
+  }
+
+  if (event.type === "REQUEST") {
+    return "requesting"
+  }
+
+  if (state !== "requesting") {
+    return state
+  }
+
+  const requestResults: Record<
+    Exclude<CameraEvent["type"], "REQUEST" | "STOP">,
+    CameraState
+  > = {
+    READY: "ready",
+    DENIED: "denied",
+    MISSING: "missing",
+    BUSY: "busy",
+    FAIL: "failed",
+  }
+
+  return requestResults[event.type]
+}

--- a/src/features/camera/use-camera-lifecycle.ts
+++ b/src/features/camera/use-camera-lifecycle.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from "react"
+
+import {
+  transitionCameraState,
+  type CameraEvent,
+} from "@/features/camera/camera-state"
+import {
+  CameraRequestError,
+  createBrowserCameraAdapter,
+  type CameraDevice,
+  type MediaStreamCameraAdapter,
+} from "@/infrastructure/camera/media-stream-adapter"
+
+export type CameraAdapter = Pick<
+  MediaStreamCameraAdapter,
+  "listDevices" | "request" | "stop"
+>
+
+export type CameraAdapterFactory = () => CameraAdapter
+
+const failureEvents = {
+  denied: "DENIED",
+  missing: "MISSING",
+  busy: "BUSY",
+  failed: "FAIL",
+} as const satisfies Record<CameraRequestError["state"], CameraEvent["type"]>
+
+export function useCameraLifecycle(
+  adapterFactory: CameraAdapterFactory = createBrowserCameraAdapter,
+) {
+  const [state, dispatch] = useReducer(transitionCameraState, "idle")
+  const [stream, setStream] = useState<MediaStream | null>(null)
+  const [devices, setDevices] = useState<CameraDevice[]>([])
+  const [selectedDeviceId, setSelectedDeviceId] = useState("")
+  const adapterRef = useRef<CameraAdapter | null>(null)
+  const requestIdRef = useRef(0)
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  const getAdapter = useCallback(() => {
+    adapterRef.current ??= adapterFactory()
+    return adapterRef.current
+  }, [adapterFactory])
+
+  const stop = useCallback(() => {
+    requestIdRef.current += 1
+    adapterRef.current?.stop()
+    setStream(null)
+    dispatch({ type: "STOP" })
+  }, [])
+
+  const start = useCallback(
+    async (deviceId = selectedDeviceId) => {
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
+      dispatch({ type: "REQUEST" })
+
+      try {
+        const adapter = getAdapter()
+        const nextStream = await adapter.request(deviceId || undefined)
+
+        if (requestId !== requestIdRef.current) {
+          adapter.stop()
+          return
+        }
+
+        setStream(nextStream)
+        dispatch({ type: "READY" })
+
+        const availableDevices = await adapter.listDevices()
+        if (requestId === requestIdRef.current) {
+          setDevices(availableDevices)
+          const activeDeviceId = nextStream
+            .getVideoTracks()[0]
+            ?.getSettings().deviceId
+          setSelectedDeviceId(
+            activeDeviceId || deviceId || availableDevices[0]?.id || "",
+          )
+        }
+      } catch (error) {
+        const failure =
+          error instanceof CameraRequestError ? error.state : "failed"
+        dispatch({ type: failureEvents[failure] })
+      }
+    },
+    [getAdapter, selectedDeviceId],
+  )
+
+  const selectDevice = useCallback(
+    (deviceId: string) => {
+      setSelectedDeviceId(deviceId)
+      void start(deviceId)
+    },
+    [start],
+  )
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.srcObject = stream
+    }
+  }, [stream])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        stop()
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+  }, [stop])
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1
+      adapterRef.current?.stop()
+    },
+    [],
+  )
+
+  return {
+    devices,
+    selectedDeviceId,
+    selectDevice,
+    start,
+    state,
+    stop,
+    videoRef,
+  }
+}

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -24,7 +24,7 @@ describe("WorkspaceShell", () => {
       screen.getByRole("region", { name: "Toile de dessin vide" }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole("region", { name: "Aperçu caméra simulé" }),
+      screen.getByRole("region", { name: "Aperçu caméra" }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: "Annuler — bientôt disponible" }),

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -53,6 +53,7 @@
   right: var(--space-xl);
   z-index: var(--z-floating-controls);
   display: grid;
+  width: 18rem;
   justify-items: center;
   gap: var(--space-sm);
 }
@@ -70,33 +71,99 @@
   border-radius: 50%;
 }
 
-.camera-preview__badge {
+.camera-preview__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1);
+}
+
+.camera-preview__loader {
+  width: 2rem;
+  height: 2rem;
+  color: var(--primary);
+  animation: camera-spin 800ms linear infinite;
+}
+
+.camera-preview__controls {
+  display: grid;
+  width: 100%;
+  justify-items: center;
+  gap: var(--space-sm);
   color: var(--foreground);
+}
+
+.camera-preview__message,
+.camera-preview__error {
+  display: flex;
+  width: 100%;
+  gap: var(--space-sm);
+}
+
+.camera-preview__message {
+  align-items: flex-start;
+  padding: var(--space-md);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  background: var(--shell-raised);
+  border-radius: var(--radius-lg);
   box-shadow: 0 0.25rem 0.5rem oklch(0.06 0.01 286 / 20%);
 }
 
-.camera-preview__landmark {
-  position: absolute;
+.camera-preview__message > svg {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.125rem;
+  color: var(--primary);
+}
+
+.camera-preview__error {
+  flex-direction: column;
+}
+
+.camera-preview__status {
+  color: var(--success-foreground);
+  background: var(--success);
+}
+
+.camera-preview__status-dot {
   width: 0.5rem;
   height: 0.5rem;
-  background: var(--success);
-  border: 2px solid var(--shell-sunken);
+  background: currentColor;
   border-radius: 50%;
 }
 
-.camera-preview__landmark--one {
-  top: 31%;
-  left: 43%;
+.camera-preview__device-field {
+  display: grid;
+  width: 100%;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  color: var(--foreground);
+  font-size: 0.75rem;
+  background: var(--shell-raised);
+  border-radius: var(--radius-lg);
 }
 
-.camera-preview__landmark--two {
-  top: 47%;
-  left: 63%;
+.camera-preview__device-field select {
+  min-height: 2.75rem;
+  padding-inline: var(--space-sm);
+  color: var(--foreground);
+  background: var(--shell-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
 }
 
-.camera-preview__landmark--three {
-  top: 64%;
-  left: 51%;
+.camera-preview__device-field select:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+@keyframes camera-spin {
+  to {
+    transform: rotate(1turn);
+  }
 }
 
 .gesture-coach {

--- a/src/infrastructure/camera/media-stream-adapter.test.ts
+++ b/src/infrastructure/camera/media-stream-adapter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  classifyCameraError,
+  MediaStreamCameraAdapter,
+} from "@/infrastructure/camera/media-stream-adapter"
+
+function createMediaStream() {
+  const stop = vi.fn()
+  const track = { stop } as unknown as MediaStreamTrack
+  const stream = {
+    getTracks: () => [track],
+  } as unknown as MediaStream
+
+  return { stop, stream }
+}
+
+describe("MediaStreamCameraAdapter", () => {
+  it("requests video without audio using privacy-conscious defaults", async () => {
+    const { stream } = createMediaStream()
+    const getUserMedia = vi.fn(() => Promise.resolve(stream))
+    const adapter = new MediaStreamCameraAdapter({
+      enumerateDevices: vi.fn(() => Promise.resolve([])),
+      getUserMedia,
+    })
+
+    await adapter.request()
+
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: false,
+      video: {
+        facingMode: { ideal: "user" },
+        height: { ideal: 720 },
+        width: { ideal: 1280 },
+      },
+    })
+  })
+
+  it("targets the selected device and stops the previous stream", async () => {
+    const first = createMediaStream()
+    const second = createMediaStream()
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first.stream)
+      .mockResolvedValueOnce(second.stream)
+    const adapter = new MediaStreamCameraAdapter({
+      enumerateDevices: vi.fn(() => Promise.resolve([])),
+      getUserMedia,
+    })
+
+    await adapter.request()
+    await adapter.request("back")
+
+    expect(first.stop).toHaveBeenCalledOnce()
+    expect(getUserMedia).toHaveBeenLastCalledWith({
+      audio: false,
+      video: {
+        deviceId: { exact: "back" },
+        facingMode: { ideal: "user" },
+        height: { ideal: 720 },
+        width: { ideal: 1280 },
+      },
+    })
+  })
+
+  it("returns only cameras and supplies labels when the browser hides them", async () => {
+    const { stream } = createMediaStream()
+    const adapter = new MediaStreamCameraAdapter({
+      enumerateDevices: vi.fn(() =>
+        Promise.resolve([
+          { deviceId: "front", kind: "videoinput", label: "FaceTime" },
+          { deviceId: "microphone", kind: "audioinput", label: "Micro" },
+          { deviceId: "back", kind: "videoinput", label: "" },
+        ] as MediaDeviceInfo[]),
+      ),
+      getUserMedia: vi.fn(() => Promise.resolve(stream)),
+    })
+
+    await expect(adapter.listDevices()).resolves.toEqual([
+      { id: "front", label: "FaceTime" },
+      { id: "back", label: "Caméra 2" },
+    ])
+  })
+
+  it.each([
+    ["NotAllowedError", "denied"],
+    ["SecurityError", "denied"],
+    ["NotFoundError", "missing"],
+    ["OverconstrainedError", "missing"],
+    ["NotReadableError", "busy"],
+    ["TrackStartError", "busy"],
+    ["UnknownError", "failed"],
+  ] as const)("classifies %s as %s", (name, expected) => {
+    expect(classifyCameraError(new DOMException("camera", name))).toBe(expected)
+  })
+
+  it("exposes a stable domain error when getUserMedia rejects", async () => {
+    const source = new DOMException("blocked", "NotAllowedError")
+    const adapter = new MediaStreamCameraAdapter({
+      enumerateDevices: vi.fn(() => Promise.resolve([])),
+      getUserMedia: vi.fn(() => Promise.reject(source)),
+    })
+
+    await expect(adapter.request()).rejects.toMatchObject({
+      cause: source,
+      name: "CameraRequestError",
+      state: "denied",
+    })
+  })
+})

--- a/src/infrastructure/camera/media-stream-adapter.ts
+++ b/src/infrastructure/camera/media-stream-adapter.ts
@@ -1,0 +1,106 @@
+import type { CameraState } from "@/features/camera/camera-state"
+
+export type CameraFailureState = Extract<
+  CameraState,
+  "denied" | "missing" | "busy" | "failed"
+>
+
+export type CameraDevice = {
+  id: string
+  label: string
+}
+
+type MediaDevicesPort = Pick<MediaDevices, "enumerateDevices" | "getUserMedia">
+
+export class CameraRequestError extends Error {
+  readonly state: CameraFailureState
+
+  constructor(state: CameraFailureState, cause?: unknown) {
+    super(`Camera request failed: ${state}`, { cause })
+    this.name = "CameraRequestError"
+    this.state = state
+  }
+}
+
+function getErrorName(error: unknown): string {
+  if (error instanceof DOMException || error instanceof Error) {
+    return error.name
+  }
+
+  return ""
+}
+
+export function classifyCameraError(error: unknown): CameraFailureState {
+  switch (getErrorName(error)) {
+    case "NotAllowedError":
+    case "PermissionDeniedError":
+    case "SecurityError":
+      return "denied"
+    case "NotFoundError":
+    case "DevicesNotFoundError":
+    case "OverconstrainedError":
+      return "missing"
+    case "NotReadableError":
+    case "TrackStartError":
+      return "busy"
+    default:
+      return "failed"
+  }
+}
+
+export class MediaStreamCameraAdapter {
+  private stream: MediaStream | null = null
+
+  constructor(private readonly mediaDevices: MediaDevicesPort) {}
+
+  async request(deviceId?: string): Promise<MediaStream> {
+    this.stop()
+
+    const video: MediaTrackConstraints = {
+      width: { ideal: 1280 },
+      height: { ideal: 720 },
+      facingMode: { ideal: "user" },
+      ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+    }
+
+    try {
+      this.stream = await this.mediaDevices.getUserMedia({
+        audio: false,
+        video,
+      })
+      return this.stream
+    } catch (error) {
+      throw new CameraRequestError(classifyCameraError(error), error)
+    }
+  }
+
+  async listDevices(): Promise<CameraDevice[]> {
+    const devices = await this.mediaDevices.enumerateDevices()
+    let cameraNumber = 0
+
+    return devices.flatMap((device) => {
+      if (device.kind !== "videoinput") {
+        return []
+      }
+
+      cameraNumber += 1
+      return {
+        id: device.deviceId,
+        label: device.label || `Caméra ${cameraNumber}`,
+      }
+    })
+  }
+
+  stop(): void {
+    this.stream?.getTracks().forEach((track) => track.stop())
+    this.stream = null
+  }
+}
+
+export function createBrowserCameraAdapter(): MediaStreamCameraAdapter {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new CameraRequestError("missing")
+  }
+
+  return new MediaStreamCameraAdapter(navigator.mediaDevices)
+}


### PR DESCRIPTION
## Objectif

Livrer le cycle de vie caméra local et explicite du lot 3 de `IMPLEMENTATION_PLAN.md`.

## Changements

- modélise les huit états caméra et leurs transitions
- encapsule `getUserMedia` dans un adaptateur testable, sans audio ni envoi réseau
- demande le consentement uniquement après une action utilisateur
- ajoute pause, reprise, sélection du périphérique et récupération après erreur
- conserve les contrôles flottants sur la toile blanche

## Preuves

- [x] `pnpm validate`
- [x] 39 tests unitaires, dont permissions et erreurs simulées
- [x] contrôle visuel Chrome headless à 1440 × 900
- [x] aucun secret, asset généré ou fichier de build ajouté
- [x] aucune décision d’architecture ne nécessite de nouvel ADR

## Promotion en production

Sans objet : la branche cible est `dev`.

## Risques et rollback

Le principal risque dépend des différences de gestion des permissions entre navigateurs. Le rollback consiste à rebasculer sur le composant caméra simulé du commit `a137544` sans affecter la toile ou la barre d’outils.