### PR TITLE
feat: translate hand landmarks into stable gestures

### DIFF
--- a/src/core/geometry/coordinate-mapping.ts
+++ b/src/core/geometry/coordinate-mapping.ts
@@ -1,0 +1,27 @@
+import type { NormalizedLandmark } from "@/infrastructure/mediapipe/hand-tracker-port"
+
+export type CanvasBounds = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export type CanvasPoint = {
+  x: number
+  y: number
+}
+
+function clampUnit(value: number) {
+  return Math.min(1, Math.max(0, value))
+}
+
+export function mapMirroredCameraPointToCanvas(
+  point: Pick<NormalizedLandmark, "x" | "y">,
+  bounds: CanvasBounds,
+): CanvasPoint {
+  return {
+    x: bounds.left + (1 - clampUnit(point.x)) * bounds.width,
+    y: bounds.top + clampUnit(point.y) * bounds.height,
+  }
+}

--- a/src/core/gestures/drawing-intentions.ts
+++ b/src/core/gestures/drawing-intentions.ts
@@ -1,0 +1,20 @@
+import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
+
+export const DRAWING_INTENTION_VERSION = 1 as const
+
+type IntentionBase = {
+  version: typeof DRAWING_INTENTION_VERSION
+  timestampMs: number
+}
+
+type PointIntention = IntentionBase & {
+  point: CanvasPoint
+}
+
+export type DrawingIntention =
+  | (PointIntention & { type: "POINTER_MOVE" })
+  | (PointIntention & { type: "DRAW_START" })
+  | (PointIntention & { type: "DRAW_MOVE" })
+  | (PointIntention & { type: "DRAW_END" })
+  | (IntentionBase & { type: "PAUSE" })
+  | (IntentionBase & { type: "TRACKING_LOST" })

--- a/src/core/gestures/gesture-classifier.test.ts
+++ b/src/core/gestures/gesture-classifier.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  fistGestureLandmarks,
+  handFromGestureFixture,
+  openHandGestureLandmarks,
+  pinchGestureLandmarks,
+  uncertainGestureLandmarks,
+  withPinchRatio,
+} from "@/test/fixtures/gesture-landmarks"
+
+import { classifyGesture } from "./gesture-classifier"
+
+describe("classifyGesture", () => {
+  it.each([
+    ["pinch", pinchGestureLandmarks, "pinch"],
+    ["open hand", openHandGestureLandmarks, "open-hand"],
+    ["fist", fistGestureLandmarks, "fist"],
+    ["uncertain hand", uncertainGestureLandmarks, "uncertain"],
+  ] as const)("classifies a %s fixture", (_name, landmarks, expected) => {
+    expect(classifyGesture(handFromGestureFixture(landmarks)).kind).toBe(
+      expected,
+    )
+  })
+
+  it("reports tracking loss when no complete hand is available", () => {
+    expect(classifyGesture(null).kind).toBe("tracking-lost")
+    expect(classifyGesture(handFromGestureFixture([])).kind).toBe(
+      "tracking-lost",
+    )
+  })
+
+  it("rejects a low-confidence hand", () => {
+    expect(
+      classifyGesture(handFromGestureFixture(pinchGestureLandmarks, 0.64)).kind,
+    ).toBe("uncertain")
+  })
+
+  it("uses separate pinch entry and exit thresholds", () => {
+    const inDeadBand = handFromGestureFixture(withPinchRatio(0.36))
+
+    expect(classifyGesture(inDeadBand, "open-hand").kind).toBe("open-hand")
+    expect(classifyGesture(inDeadBand, "pinch").kind).toBe("pinch")
+  })
+
+  it.each([
+    [0.3, "open-hand", "pinch"],
+    [0.301, "open-hand", "open-hand"],
+    [0.42, "pinch", "pinch"],
+    [0.421, "pinch", "open-hand"],
+  ] as const)(
+    "keeps ratio %s stable from %s",
+    (ratio, previousKind, expected) => {
+      const hand = handFromGestureFixture(withPinchRatio(ratio))
+      expect(classifyGesture(hand, previousKind).kind).toBe(expected)
+    },
+  )
+})

--- a/src/core/gestures/gesture-classifier.ts
+++ b/src/core/gestures/gesture-classifier.ts
@@ -1,0 +1,132 @@
+import type {
+  NormalizedLandmark,
+  TrackedHand,
+} from "@/infrastructure/mediapipe/hand-tracker-port"
+
+import { GESTURE_THRESHOLDS } from "./gesture-thresholds"
+
+export type GestureKind =
+  "pinch" | "open-hand" | "fist" | "uncertain" | "tracking-lost"
+
+export type GestureClassification = {
+  kind: GestureKind
+  confidence: number
+  pinchRatio: number | null
+  extendedFingerCount: number
+}
+
+const WRIST = 0
+const THUMB_TIP = 4
+const MIDDLE_MCP = 9
+const FINGER_JOINTS = [
+  { pip: 6, tip: 8 },
+  { pip: 10, tip: 12 },
+  { pip: 14, tip: 16 },
+  { pip: 18, tip: 20 },
+] as const
+
+function distance(a: NormalizedLandmark, b: NormalizedLandmark) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+function landmarkAt(landmarks: NormalizedLandmark[], index: number) {
+  return landmarks[index] ?? null
+}
+
+function countExtendedFingers(landmarks: NormalizedLandmark[]) {
+  const wrist = landmarkAt(landmarks, WRIST)
+  if (!wrist) return 0
+
+  return FINGER_JOINTS.reduce((count, { pip, tip }) => {
+    const pipLandmark = landmarkAt(landmarks, pip)
+    const tipLandmark = landmarkAt(landmarks, tip)
+    if (!pipLandmark || !tipLandmark) return count
+
+    const extensionRatio =
+      distance(wrist, tipLandmark) / distance(wrist, pipLandmark)
+    return (
+      count +
+      (extensionRatio >= GESTURE_THRESHOLDS.fingerExtensionRatio ? 1 : 0)
+    )
+  }, 0)
+}
+
+function measurePinchRatio(landmarks: NormalizedLandmark[]) {
+  const wrist = landmarkAt(landmarks, WRIST)
+  const thumbTip = landmarkAt(landmarks, THUMB_TIP)
+  const indexTip = landmarkAt(landmarks, 8)
+  const middleMcp = landmarkAt(landmarks, MIDDLE_MCP)
+  if (!wrist || !thumbTip || !indexTip || !middleMcp) return null
+
+  const palmSize = distance(wrist, middleMcp)
+  if (palmSize <= Number.EPSILON) return null
+  return distance(thumbTip, indexTip) / palmSize
+}
+
+export function classifyGesture(
+  hand: TrackedHand | null,
+  previousKind: GestureKind = "tracking-lost",
+): GestureClassification {
+  if (!hand || hand.landmarks.length < 21) {
+    return {
+      kind: "tracking-lost",
+      confidence: 0,
+      pinchRatio: null,
+      extendedFingerCount: 0,
+    }
+  }
+
+  const pinchRatio = measurePinchRatio(hand.landmarks)
+  const extendedFingerCount = countExtendedFingers(hand.landmarks)
+  if (
+    hand.confidence < GESTURE_THRESHOLDS.minimumHandConfidence ||
+    pinchRatio === null
+  ) {
+    return {
+      kind: "uncertain",
+      confidence: hand.confidence,
+      pinchRatio,
+      extendedFingerCount,
+    }
+  }
+
+  if (extendedFingerCount <= GESTURE_THRESHOLDS.fistMaximumExtendedFingers) {
+    return {
+      kind: "fist",
+      confidence: hand.confidence,
+      pinchRatio,
+      extendedFingerCount,
+    }
+  }
+
+  const pinchBoundary =
+    previousKind === "pinch"
+      ? GESTURE_THRESHOLDS.pinchExitRatio
+      : GESTURE_THRESHOLDS.pinchEnterRatio
+  if (pinchRatio <= pinchBoundary + Number.EPSILON * 16) {
+    return {
+      kind: "pinch",
+      confidence: hand.confidence,
+      pinchRatio,
+      extendedFingerCount,
+    }
+  }
+
+  if (
+    extendedFingerCount >= GESTURE_THRESHOLDS.openHandMinimumExtendedFingers
+  ) {
+    return {
+      kind: "open-hand",
+      confidence: hand.confidence,
+      pinchRatio,
+      extendedFingerCount,
+    }
+  }
+
+  return {
+    kind: "uncertain",
+    confidence: hand.confidence,
+    pinchRatio,
+    extendedFingerCount,
+  }
+}

--- a/src/core/gestures/gesture-fixtures.test.ts
+++ b/src/core/gestures/gesture-fixtures.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import type { NormalizedLandmark } from "@/infrastructure/mediapipe/hand-tracker-port"
+import {
+  fistGestureLandmarks,
+  openHandGestureLandmarks,
+  pinchGestureLandmarks,
+  uncertainGestureLandmarks,
+  withPinchRatio,
+} from "@/test/fixtures/gesture-landmarks"
+
+function distance(a: NormalizedLandmark, b: NormalizedLandmark) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+function pinchRatio(landmarks: NormalizedLandmark[]) {
+  const wrist = landmarks[0]
+  const middleMcp = landmarks[9]
+  const thumbTip = landmarks[4]
+  const indexTip = landmarks[8]
+
+  if (!wrist || !middleMcp || !thumbTip || !indexTip) {
+    throw new Error("Expected a complete hand fixture")
+  }
+
+  return distance(thumbTip, indexTip) / distance(wrist, middleMcp)
+}
+
+describe("gesture classification fixtures", () => {
+  it.each([
+    ["pinch", pinchGestureLandmarks],
+    ["open hand", openHandGestureLandmarks],
+    ["fist", fistGestureLandmarks],
+    ["uncertain hand", uncertainGestureLandmarks],
+  ])("provides a complete %s pose", (_name, landmarks) => {
+    expect(landmarks).toHaveLength(21)
+    expect(
+      landmarks.every(({ x, y }) => x >= 0 && x <= 1 && y >= 0 && y <= 1),
+    ).toBe(true)
+  })
+
+  it("keeps the pinch fixture clearly below the open-hand ratio", () => {
+    expect(pinchRatio(pinchGestureLandmarks)).toBeLessThan(0.3)
+    expect(pinchRatio(openHandGestureLandmarks)).toBeGreaterThan(0.5)
+  })
+
+  it.each([0.29, 0.3, 0.42, 0.43])(
+    "creates exact non-regression poses around ratio %s",
+    (ratio) => {
+      expect(pinchRatio(withPinchRatio(ratio))).toBeCloseTo(ratio, 8)
+    },
+  )
+})

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  fistGestureLandmarks,
+  handFromGestureFixture,
+  openHandGestureLandmarks,
+  pinchGestureLandmarks,
+  uncertainGestureLandmarks,
+  withPinchRatio,
+} from "@/test/fixtures/gesture-landmarks"
+
+import { classifyGesture, type GestureKind } from "./gesture-classifier"
+import {
+  initialGestureMachineState,
+  transitionGestureState,
+} from "./gesture-state-machine"
+import { PointerMotionFilter } from "./pointer-motion-filter"
+
+function classifySequence(ratios: number[], initial: GestureKind) {
+  let previous = initial
+  return ratios.map((ratio) => {
+    const classification = classifyGesture(
+      handFromGestureFixture(withPinchRatio(ratio)),
+      previous,
+    )
+    previous = classification.kind
+    return classification.kind
+  })
+}
+
+describe("gesture jitter and accidental activation resistance", () => {
+  it("does not chatter while a pinched hand jitters inside the dead band", () => {
+    expect(
+      classifySequence([0.29, 0.31, 0.38, 0.34, 0.41, 0.32], "open-hand"),
+    ).toEqual(["pinch", "pinch", "pinch", "pinch", "pinch", "pinch"])
+  })
+
+  it("does not enter pinch while an open hand jitters above entry", () => {
+    expect(
+      classifySequence([0.31, 0.38, 0.33, 0.41, 0.305], "open-hand"),
+    ).toEqual(["open-hand", "open-hand", "open-hand", "open-hand", "open-hand"])
+  })
+
+  it("requires crossing the exit boundary before releasing pinch", () => {
+    expect(classifySequence([0.41, 0.419, 0.43], "pinch")).toEqual([
+      "pinch",
+      "pinch",
+      "open-hand",
+    ])
+  })
+
+  it("never emits drawing activation for non-pinch safety poses", () => {
+    const safetyPoses = [
+      fistGestureLandmarks,
+      openHandGestureLandmarks,
+      uncertainGestureLandmarks,
+    ]
+
+    for (const landmarks of safetyPoses) {
+      const gesture = classifyGesture(handFromGestureFixture(landmarks)).kind
+      const { intentions } = transitionGestureState(
+        initialGestureMachineState,
+        { gesture, point: { x: 100, y: 100 }, timestampMs: 16 },
+      )
+      expect(intentions.map(({ type }) => type)).not.toContain("DRAW_START")
+    }
+  })
+
+  it("rejects a pinch when tracking confidence is insufficient", () => {
+    const gesture = classifyGesture(
+      handFromGestureFixture(pinchGestureLandmarks, 0.2),
+    ).kind
+    const { intentions } = transitionGestureState(initialGestureMachineState, {
+      gesture,
+      point: { x: 100, y: 100 },
+      timestampMs: 16,
+    })
+
+    expect(gesture).toBe("uncertain")
+    expect(intentions.map(({ type }) => type)).not.toContain("DRAW_START")
+  })
+
+  it("ends an active stroke when the hand disappears", () => {
+    const started = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      point: { x: 10, y: 20 },
+      timestampMs: 0,
+    })
+    const lost = transitionGestureState(started.state, {
+      gesture: classifyGesture(null).kind,
+      point: null,
+      timestampMs: 16,
+    })
+
+    expect(lost.intentions.map(({ type }) => type)).toEqual([
+      "DRAW_END",
+      "TRACKING_LOST",
+    ])
+  })
+
+  it("treats malformed or degenerate landmark geometry as uncertain", () => {
+    const incomplete = Array.from({ length: 21 }, () => undefined)
+    const incompleteHand = handFromGestureFixture(
+      incomplete as unknown as typeof pinchGestureLandmarks,
+    )
+    const degenerate = openHandGestureLandmarks.map((landmark) => ({
+      ...landmark,
+    }))
+    degenerate[9] = { ...degenerate[0]! }
+
+    expect(classifyGesture(incompleteHand).kind).toBe("uncertain")
+    expect(classifyGesture(handFromGestureFixture(degenerate)).kind).toBe(
+      "uncertain",
+    )
+  })
+
+  it("does not start drawing when a pinch has no reliable pointer", () => {
+    const transition = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      point: null,
+      timestampMs: 16,
+    })
+
+    expect(transition).toEqual({
+      state: { mode: "idle", lastPoint: null },
+      intentions: [],
+    })
+  })
+
+  it("rejects an invalid pointer smoothing time constant", () => {
+    expect(() => new PointerMotionFilter({ timeConstantMs: 0 })).toThrow(
+      "greater than zero",
+    )
+  })
+})

--- a/src/core/gestures/gesture-state-machine.test.ts
+++ b/src/core/gestures/gesture-state-machine.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import { DRAWING_INTENTION_VERSION } from "./drawing-intentions"
+import {
+  initialGestureMachineState,
+  transitionGestureState,
+} from "./gesture-state-machine"
+
+describe("transitionGestureState", () => {
+  it("emits pointer and drawing intentions for a pinch sequence", () => {
+    const started = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      point: { x: 10, y: 20 },
+      timestampMs: 100,
+    })
+    const moved = transitionGestureState(started.state, {
+      gesture: "pinch",
+      point: { x: 12, y: 24 },
+      timestampMs: 116,
+    })
+
+    expect(started.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_START",
+    ])
+    expect(moved.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_MOVE",
+    ])
+    expect(moved.state.mode).toBe("drawing")
+  })
+
+  it("ends a stroke before pausing on an open hand", () => {
+    const state = {
+      mode: "drawing" as const,
+      lastPoint: { x: 12, y: 24 },
+    }
+    const transition = transitionGestureState(state, {
+      gesture: "open-hand",
+      point: { x: 15, y: 25 },
+      timestampMs: 132,
+    })
+
+    expect(transition.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_END",
+      "PAUSE",
+    ])
+    expect(transition.state.mode).toBe("paused")
+  })
+
+  it("ends a stroke once and never extrapolates on tracking loss", () => {
+    const drawingState = {
+      mode: "drawing" as const,
+      lastPoint: { x: 30, y: 40 },
+    }
+    const lost = transitionGestureState(drawingState, {
+      gesture: "tracking-lost",
+      point: { x: 999, y: 999 },
+      timestampMs: 200,
+    })
+    const stillLost = transitionGestureState(lost.state, {
+      gesture: "tracking-lost",
+      point: null,
+      timestampMs: 216,
+    })
+
+    expect(lost.intentions).toEqual([
+      {
+        version: DRAWING_INTENTION_VERSION,
+        type: "DRAW_END",
+        point: { x: 30, y: 40 },
+        timestampMs: 200,
+      },
+      {
+        version: DRAWING_INTENTION_VERSION,
+        type: "TRACKING_LOST",
+        timestampMs: 200,
+      },
+    ])
+    expect(stillLost.intentions).toEqual([])
+    expect(stillLost.state.lastPoint).toEqual({ x: 30, y: 40 })
+  })
+
+  it("pauses safely when classification becomes uncertain", () => {
+    const transition = transitionGestureState(
+      { mode: "drawing", lastPoint: { x: 4, y: 8 } },
+      { gesture: "uncertain", point: { x: 20, y: 40 }, timestampMs: 50 },
+    )
+
+    expect(transition.intentions.map(({ type }) => type)).toEqual([
+      "DRAW_END",
+      "PAUSE",
+    ])
+    expect(transition.state).toEqual({
+      mode: "paused",
+      lastPoint: { x: 4, y: 8 },
+    })
+  })
+
+  it("versions every emitted intention", () => {
+    const { intentions } = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      point: { x: 1, y: 2 },
+      timestampMs: 10,
+    })
+
+    expect(intentions.every(({ version }) => version === 1)).toBe(true)
+  })
+})

--- a/src/core/gestures/gesture-state-machine.ts
+++ b/src/core/gestures/gesture-state-machine.ts
@@ -1,0 +1,118 @@
+import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
+
+import type { GestureKind } from "./gesture-classifier"
+import {
+  DRAWING_INTENTION_VERSION,
+  type DrawingIntention,
+} from "./drawing-intentions"
+
+export type GestureMachineMode = "idle" | "drawing" | "paused" | "lost"
+
+export type GestureMachineState = {
+  mode: GestureMachineMode
+  lastPoint: CanvasPoint | null
+}
+
+export type GestureFrame = {
+  gesture: GestureKind
+  point: CanvasPoint | null
+  timestampMs: number
+}
+
+export type GestureTransition = {
+  state: GestureMachineState
+  intentions: DrawingIntention[]
+}
+
+export const initialGestureMachineState: GestureMachineState = {
+  mode: "idle",
+  lastPoint: null,
+}
+
+function pointIntention(
+  type: "POINTER_MOVE" | "DRAW_START" | "DRAW_MOVE" | "DRAW_END",
+  point: CanvasPoint,
+  timestampMs: number,
+): DrawingIntention {
+  return { version: DRAWING_INTENTION_VERSION, type, point, timestampMs }
+}
+
+function signalIntention(
+  type: "PAUSE" | "TRACKING_LOST",
+  timestampMs: number,
+): DrawingIntention {
+  return { version: DRAWING_INTENTION_VERSION, type, timestampMs }
+}
+
+function stopDrawing(
+  state: GestureMachineState,
+  intentions: DrawingIntention[],
+  timestampMs: number,
+) {
+  if (state.mode === "drawing" && state.lastPoint) {
+    intentions.push(pointIntention("DRAW_END", state.lastPoint, timestampMs))
+  }
+}
+
+export function transitionGestureState(
+  state: GestureMachineState,
+  frame: GestureFrame,
+): GestureTransition {
+  const intentions: DrawingIntention[] = []
+  const visiblePoint =
+    frame.gesture === "tracking-lost" || frame.gesture === "uncertain"
+      ? null
+      : frame.point
+
+  if (visiblePoint) {
+    intentions.push(
+      pointIntention("POINTER_MOVE", visiblePoint, frame.timestampMs),
+    )
+  }
+
+  if (frame.gesture === "pinch" && visiblePoint) {
+    const drawType = state.mode === "drawing" ? "DRAW_MOVE" : "DRAW_START"
+    intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
+    return {
+      state: { mode: "drawing", lastPoint: visiblePoint },
+      intentions,
+    }
+  }
+
+  if (frame.gesture === "tracking-lost") {
+    stopDrawing(state, intentions, frame.timestampMs)
+    if (state.mode !== "lost") {
+      intentions.push(signalIntention("TRACKING_LOST", frame.timestampMs))
+    }
+    return {
+      state: { mode: "lost", lastPoint: state.lastPoint },
+      intentions,
+    }
+  }
+
+  if (
+    frame.gesture === "open-hand" ||
+    frame.gesture === "fist" ||
+    frame.gesture === "uncertain"
+  ) {
+    stopDrawing(state, intentions, frame.timestampMs)
+    if (state.mode !== "paused") {
+      intentions.push(signalIntention("PAUSE", frame.timestampMs))
+    }
+    return {
+      state: {
+        mode: "paused",
+        lastPoint: visiblePoint ?? state.lastPoint,
+      },
+      intentions,
+    }
+  }
+
+  return {
+    state: {
+      mode: "idle",
+      lastPoint: visiblePoint ?? state.lastPoint,
+    },
+    intentions,
+  }
+}

--- a/src/core/gestures/gesture-thresholds.ts
+++ b/src/core/gestures/gesture-thresholds.ts
@@ -1,0 +1,14 @@
+export const GESTURE_THRESHOLDS = {
+  /** Minimum tracker confidence before a hand may produce a gesture. */
+  minimumHandConfidence: 0.65,
+  /** Thumb-to-index distance, divided by palm size, required to enter pinch. */
+  pinchEnterRatio: 0.3,
+  /** Larger release boundary that prevents chatter around pinch entry. */
+  pinchExitRatio: 0.42,
+  /** Fingertip must exceed its PIP-to-wrist distance by this factor. */
+  fingerExtensionRatio: 1.12,
+  /** Index through little finger count needed for an open hand. */
+  openHandMinimumExtendedFingers: 4,
+  /** Maximum extended fingers accepted as a fist. */
+  fistMaximumExtendedFingers: 0,
+} as const

--- a/src/core/gestures/pointer-motion-filter.test.ts
+++ b/src/core/gestures/pointer-motion-filter.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
+
+import { PointerMotionFilter } from "./pointer-motion-filter"
+
+describe("mapMirroredCameraPointToCanvas", () => {
+  it("mirrors horizontal camera coordinates into canvas coordinates", () => {
+    expect(
+      mapMirroredCameraPointToCanvas(
+        { x: 0.25, y: 0.4 },
+        { left: 10, top: 20, width: 800, height: 600 },
+      ),
+    ).toEqual({ x: 610, y: 260 })
+  })
+
+  it("clamps landmarks outside the normalized camera frame", () => {
+    expect(
+      mapMirroredCameraPointToCanvas(
+        { x: -0.2, y: 1.4 },
+        { left: 0, top: 0, width: 100, height: 50 },
+      ),
+    ).toEqual({ x: 100, y: 50 })
+  })
+})
+
+describe("PointerMotionFilter", () => {
+  it("smooths pointer movement over elapsed time", () => {
+    const filter = new PointerMotionFilter({ timeConstantMs: 100 })
+
+    expect(filter.update({ x: 0, y: 0 }, 0).point).toEqual({ x: 0, y: 0 })
+    const moved = filter.update({ x: 100, y: 50 }, 100).point
+
+    expect(moved?.x).toBeCloseTo(63.21, 2)
+    expect(moved?.y).toBeCloseTo(31.61, 2)
+  })
+
+  it("locks the last reliable position without extrapolating on loss", () => {
+    const filter = new PointerMotionFilter()
+    filter.update({ x: 20, y: 30 }, 0)
+    const lastReliable = filter.update({ x: 40, y: 50 }, 45)
+
+    expect(filter.update(null, 90)).toEqual({
+      point: lastReliable.point,
+      reliable: false,
+    })
+    expect(filter.update(null, 10_000)).toEqual({
+      point: lastReliable.point,
+      reliable: false,
+    })
+  })
+
+  it("restarts from the next reliable point after tracking loss", () => {
+    const filter = new PointerMotionFilter()
+    filter.update({ x: 10, y: 10 }, 0)
+    filter.update(null, 16)
+
+    expect(filter.update({ x: 90, y: 80 }, 32)).toEqual({
+      point: { x: 90, y: 80 },
+      reliable: true,
+    })
+  })
+
+  it("can clear the last reliable position", () => {
+    const filter = new PointerMotionFilter()
+    filter.update({ x: 10, y: 10 }, 0)
+    filter.reset()
+
+    expect(filter.update(null, 16)).toEqual({ point: null, reliable: false })
+  })
+})

--- a/src/core/gestures/pointer-motion-filter.ts
+++ b/src/core/gestures/pointer-motion-filter.ts
@@ -1,0 +1,60 @@
+import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
+
+export type FilteredPointer = {
+  point: CanvasPoint | null
+  reliable: boolean
+}
+
+export type PointerMotionFilterOptions = {
+  timeConstantMs?: number
+}
+
+const DEFAULT_TIME_CONSTANT_MS = 45
+
+export class PointerMotionFilter {
+  readonly #timeConstantMs: number
+  #lastReliablePoint: CanvasPoint | null = null
+  #lastTimestampMs: number | null = null
+
+  constructor(options: PointerMotionFilterOptions = {}) {
+    this.#timeConstantMs = options.timeConstantMs ?? DEFAULT_TIME_CONSTANT_MS
+    if (this.#timeConstantMs <= 0) {
+      throw new Error("Pointer filter timeConstantMs must be greater than zero")
+    }
+  }
+
+  update(
+    point: CanvasPoint | null,
+    timestampMs: number,
+    reliable = point !== null,
+  ): FilteredPointer {
+    if (!point || !reliable) {
+      this.#lastTimestampMs = null
+      return { point: this.#lastReliablePoint, reliable: false }
+    }
+
+    if (!this.#lastReliablePoint || this.#lastTimestampMs === null) {
+      this.#lastReliablePoint = { ...point }
+      this.#lastTimestampMs = timestampMs
+      return { point: this.#lastReliablePoint, reliable: true }
+    }
+
+    const elapsedMs = Math.max(0, timestampMs - this.#lastTimestampMs)
+    const alpha = 1 - Math.exp(-elapsedMs / this.#timeConstantMs)
+    this.#lastReliablePoint = {
+      x:
+        this.#lastReliablePoint.x +
+        (point.x - this.#lastReliablePoint.x) * alpha,
+      y:
+        this.#lastReliablePoint.y +
+        (point.y - this.#lastReliablePoint.y) * alpha,
+    }
+    this.#lastTimestampMs = timestampMs
+    return { point: this.#lastReliablePoint, reliable: true }
+  }
+
+  reset() {
+    this.#lastReliablePoint = null
+    this.#lastTimestampMs = null
+  }
+}

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -38,6 +38,14 @@ const trackingContent = {
   },
 } as const
 
+const gestureLabels = {
+  pinch: "Pincement",
+  "open-hand": "Main ouverte",
+  fist: "Poing",
+  uncertain: "Geste incertain",
+  "tracking-lost": "Aucun geste",
+} as const
+
 const errorContent = {
   denied: {
     title: "Accès caméra refusé",
@@ -77,6 +85,7 @@ export function CameraPreview({
   } = useCameraLifecycle(adapterFactory)
   const {
     canvasRef,
+    gesture,
     metrics,
     state: trackingState,
   } = useHandTracking(state === "ready", videoRef, trackerFactory)
@@ -154,6 +163,11 @@ export function CameraPreview({
               <span aria-hidden="true" className="camera-preview__status-dot" />
               {trackingStatus.label}
             </Badge>
+            {import.meta.env.DEV ? (
+              <Badge variant="outline" aria-label="Geste détecté">
+                Geste · {gestureLabels[gesture]}
+              </Badge>
+            ) : null}
             {import.meta.env.DEV && metrics ? (
               <span className="camera-preview__metrics">
                 {Math.round(metrics.inferenceMs)} ms · {metrics.droppedFrames}{" "}

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -164,7 +164,11 @@ export function CameraPreview({
               {trackingStatus.label}
             </Badge>
             {import.meta.env.DEV ? (
-              <Badge variant="outline" aria-label="Geste détecté">
+              <Badge
+                variant="outline"
+                className="camera-preview__gesture"
+                aria-label="Geste détecté"
+              >
                 Geste · {gestureLabels[gesture]}
               </Badge>
             ) : null}

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState, type RefObject } from "react"
 
+import {
+  classifyGesture,
+  type GestureKind,
+} from "@/core/gestures/gesture-classifier"
 import type {
   HandTrackerMetrics,
   HandTrackerPort,
@@ -29,6 +33,7 @@ export function useHandTracking(
 ) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
+  const [gesture, setGesture] = useState<GestureKind>("tracking-lost")
   const [metrics, setMetrics] = useState<HandTrackerMetrics | null>(null)
 
   useEffect(() => {
@@ -44,6 +49,7 @@ export function useHandTracking(
     }
 
     let active = true
+    let previousGesture: GestureKind = "tracking-lost"
     const renderer = new LandmarkOverlayRenderer(canvas, video)
     let tracker: HandTrackerPort
     try {
@@ -61,6 +67,14 @@ export function useHandTracking(
       onResult: (result, quality) => {
         renderer.render(result)
         if (active) {
+          const classification = classifyGesture(
+            result.hands[0] ?? null,
+            previousGesture,
+          )
+          previousGesture = classification.kind
+          setGesture((current) =>
+            current === classification.kind ? current : classification.kind,
+          )
           setState((current) => (current === quality ? current : quality))
         }
       },
@@ -74,6 +88,7 @@ export function useHandTracking(
     queueMicrotask(() => {
       if (active) {
         setState("initializing")
+        setGesture("tracking-lost")
         setMetrics(null)
       }
     })
@@ -104,6 +119,7 @@ export function useHandTracking(
 
   return {
     canvasRef,
+    gesture: enabled ? gesture : "tracking-lost",
     metrics: enabled ? metrics : null,
     state: enabled ? state : "idle",
   }

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -153,6 +153,13 @@
   background: var(--destructive);
 }
 
+.camera-preview__gesture {
+  color: var(--foreground);
+  background: var(--shell-raised);
+  border-color: transparent;
+  box-shadow: 0 0.125rem 0.25rem oklch(0.06 0.01 286 / 18%);
+}
+
 .camera-preview__metrics {
   color: var(--muted-foreground);
   font-family: var(--font-mono);

--- a/src/test/fixtures/gesture-landmarks.ts
+++ b/src/test/fixtures/gesture-landmarks.ts
@@ -62,7 +62,7 @@ export const fistGestureLandmarks = pose({
 
 export const uncertainGestureLandmarks = pose({
   4: [0.34, 0.44],
-  8: [0.42, 0.48],
+  8: [0.42, 0.3],
   12: [0.5, 0.47],
   16: [0.58, 0.49],
   20: [0.65, 0.53],

--- a/src/test/fixtures/gesture-landmarks.ts
+++ b/src/test/fixtures/gesture-landmarks.ts
@@ -1,0 +1,103 @@
+import type {
+  NormalizedLandmark,
+  TrackedHand,
+} from "@/infrastructure/mediapipe/hand-tracker-port"
+
+type Point = readonly [x: number, y: number]
+
+const basePose: Point[] = [
+  [0.5, 0.86],
+  [0.4, 0.72],
+  [0.33, 0.62],
+  [0.28, 0.52],
+  [0.23, 0.43],
+  [0.42, 0.6],
+  [0.4, 0.44],
+  [0.39, 0.29],
+  [0.38, 0.14],
+  [0.5, 0.57],
+  [0.5, 0.39],
+  [0.5, 0.23],
+  [0.5, 0.08],
+  [0.58, 0.61],
+  [0.6, 0.45],
+  [0.61, 0.31],
+  [0.62, 0.18],
+  [0.66, 0.67],
+  [0.7, 0.54],
+  [0.72, 0.43],
+  [0.74, 0.33],
+]
+
+function pose(overrides: Partial<Record<number, Point>> = {}) {
+  return basePose.map(([x, y], index): NormalizedLandmark => {
+    const point = overrides[index]
+    return { x: point?.[0] ?? x, y: point?.[1] ?? y, z: 0 }
+  })
+}
+
+export const openHandGestureLandmarks = pose()
+
+export const pinchGestureLandmarks = pose({
+  3: [0.34, 0.28],
+  4: [0.38, 0.16],
+})
+
+export const fistGestureLandmarks = pose({
+  3: [0.42, 0.62],
+  4: [0.47, 0.64],
+  6: [0.43, 0.55],
+  7: [0.46, 0.6],
+  8: [0.49, 0.64],
+  10: [0.5, 0.54],
+  11: [0.52, 0.59],
+  12: [0.53, 0.64],
+  14: [0.57, 0.56],
+  15: [0.56, 0.61],
+  16: [0.55, 0.66],
+  18: [0.64, 0.6],
+  19: [0.62, 0.65],
+  20: [0.59, 0.69],
+})
+
+export const uncertainGestureLandmarks = pose({
+  4: [0.34, 0.44],
+  8: [0.42, 0.48],
+  12: [0.5, 0.47],
+  16: [0.58, 0.49],
+  20: [0.65, 0.53],
+})
+
+export function handFromGestureFixture(
+  landmarks: NormalizedLandmark[],
+  confidence = 0.98,
+): TrackedHand {
+  return {
+    handedness: "Right",
+    confidence,
+    landmarks,
+    worldLandmarks: landmarks,
+  }
+}
+
+export function withPinchRatio(
+  ratio: number,
+  source = pinchGestureLandmarks,
+): NormalizedLandmark[] {
+  const landmarks = source.map((landmark) => ({ ...landmark }))
+  const wrist = landmarks[0]
+  const middleMcp = landmarks[9]
+  const indexTip = landmarks[8]
+
+  if (!wrist || !middleMcp || !indexTip) {
+    throw new Error("Gesture fixture must contain the 21 MediaPipe landmarks")
+  }
+
+  const palmSize = Math.hypot(middleMcp.x - wrist.x, middleMcp.y - wrist.y)
+  landmarks[4] = {
+    x: indexTip.x - ratio * palmSize,
+    y: indexTip.y,
+    z: indexTip.z,
+  }
+  return landmarks
+}


### PR DESCRIPTION
## Résumé
- classifie pincement, main ouverte, poing, incertitude et perte de suivi
- applique hystérésis, filtrage temporel et mapping miroir caméra vers Canvas
- émet des intentions de dessin versionnées via une machine d’état pure
- couvre le bruit de seuil et les activations accidentelles
- expose un diagnostic de geste lisible uniquement en développement

## Vérifications
- [x] pnpm validate`n- [x] pnpm test:coverage`n- [x] core/gestures : 100 % lignes, 97,5 % branches
- [x] aucune dépendance ajoutée

## Validation manuelle
- [x] webcam réelle : pincement, main ouverte, poing et perte de suivi détectés
- [x] une main immobile près du seuil ne bascule pas rapidement entre dessin et pause
- [x] diagnostic de développement lisible sur la toile blanche