### PR TITLE
feat: add the two-layer drawing engine

### DIFF
--- a/src/core/drawing/canvas-drawing-controller.ts
+++ b/src/core/drawing/canvas-drawing-controller.ts
@@ -1,0 +1,129 @@
+import type { DrawingIntention } from "@/core/gestures/drawing-intentions"
+import type { CanvasBounds } from "@/core/geometry/coordinate-mapping"
+
+import { applyDrawingCommand } from "./drawing-commands"
+import {
+  createDrawingHistory,
+  recordDrawing,
+  redoDrawing,
+  undoDrawing,
+  type DrawingHistory,
+} from "./drawing-history"
+import {
+  emptyDrawingDocument,
+  type NormalizedPoint,
+  type Stroke,
+  type StrokeTool,
+} from "./drawing-model"
+import { TwoLayerCanvasRenderer } from "./two-layer-canvas-renderer"
+
+export type DrawingStyle = {
+  tool: StrokeTool
+  color: string
+  width: number
+}
+
+export class CanvasDrawingController {
+  readonly #renderer: TwoLayerCanvasRenderer
+  #history: DrawingHistory
+  #bounds: CanvasBounds = { left: 0, top: 0, width: 1, height: 1 }
+  #style: DrawingStyle = { tool: "pen", color: "#111111", width: 0.008 }
+  #activeStroke: Stroke | null = null
+  #nextStrokeId = 1
+
+  constructor(renderer: TwoLayerCanvasRenderer, historyLimit = 50) {
+    this.#renderer = renderer
+    this.#history = createDrawingHistory(emptyDrawingDocument, historyLimit)
+  }
+
+  get document() {
+    return this.#history.present
+  }
+
+  setBounds(bounds: CanvasBounds) {
+    this.#bounds = bounds
+    this.#renderer.resize(bounds.width, bounds.height)
+    this.#renderer.setDocument(this.#history.present)
+  }
+
+  setStyle(style: DrawingStyle) {
+    this.#style = style
+  }
+
+  handle(intention: DrawingIntention) {
+    switch (intention.type) {
+      case "POINTER_MOVE":
+        this.#renderer.setPointer(this.#toLocalPoint(intention.point))
+        break
+      case "DRAW_START": {
+        const point = this.#normalize(intention.point)
+        this.#activeStroke = {
+          id: `stroke-${this.#nextStrokeId++}`,
+          ...this.#style,
+          points: [point],
+        }
+        this.#renderer.setPreviewStroke(this.#activeStroke)
+        break
+      }
+      case "DRAW_MOVE":
+        if (this.#activeStroke) {
+          this.#activeStroke = {
+            ...this.#activeStroke,
+            points: [
+              ...this.#activeStroke.points,
+              this.#normalize(intention.point),
+            ],
+          }
+          this.#renderer.setPreviewStroke(this.#activeStroke)
+        }
+        break
+      case "DRAW_END":
+      case "PAUSE":
+      case "TRACKING_LOST":
+        this.#finishStroke()
+        if (intention.type === "TRACKING_LOST") {
+          this.#renderer.setPointer(null)
+        }
+        break
+    }
+  }
+
+  undo() {
+    this.#history = undoDrawing(this.#history)
+    this.#renderer.setDocument(this.#history.present)
+  }
+
+  redo() {
+    this.#history = redoDrawing(this.#history)
+    this.#renderer.setDocument(this.#history.present)
+  }
+
+  #finishStroke() {
+    if (!this.#activeStroke) return
+    const next = applyDrawingCommand(this.#history.present, {
+      type: "ADD_STROKE",
+      stroke: this.#activeStroke,
+    })
+    this.#history = recordDrawing(this.#history, next)
+    this.#activeStroke = null
+    this.#renderer.setPreviewStroke(null)
+    this.#renderer.setDocument(this.#history.present)
+  }
+
+  #toLocalPoint(point: { x: number; y: number }) {
+    return { x: point.x - this.#bounds.left, y: point.y - this.#bounds.top }
+  }
+
+  #normalize(point: { x: number; y: number }): NormalizedPoint {
+    return {
+      x: Math.min(
+        1,
+        Math.max(0, (point.x - this.#bounds.left) / this.#bounds.width),
+      ),
+      y: Math.min(
+        1,
+        Math.max(0, (point.y - this.#bounds.top) / this.#bounds.height),
+      ),
+    }
+  }
+}

--- a/src/core/drawing/drawing-commands.test.ts
+++ b/src/core/drawing/drawing-commands.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import { applyDrawingCommand } from "./drawing-commands"
+import { emptyDrawingDocument, type Stroke } from "./drawing-model"
+
+const stroke: Stroke = {
+  id: "stroke-1",
+  tool: "pen",
+  color: "#111111",
+  width: 0.02,
+  points: [
+    { x: 0.2, y: 0.2 },
+    { x: 0.3, y: 0.3 },
+  ],
+}
+
+describe("applyDrawingCommand", () => {
+  it("adds a stroke without mutating the previous document", () => {
+    const next = applyDrawingCommand(emptyDrawingDocument, {
+      type: "ADD_STROKE",
+      stroke,
+    })
+
+    expect(next.strokes).toEqual([stroke])
+    expect(emptyDrawingDocument.strokes).toEqual([])
+  })
+
+  it("removes strokes touched by the eraser radius", () => {
+    const document = { strokes: [stroke] }
+    const next = applyDrawingCommand(document, {
+      type: "ERASE_AT",
+      point: { x: 0.31, y: 0.3 },
+      radius: 0.01,
+    })
+
+    expect(next.strokes).toEqual([])
+    expect(document.strokes).toEqual([stroke])
+  })
+
+  it("preserves identity when an eraser or clear command has no effect", () => {
+    const document = { strokes: [stroke] }
+    expect(
+      applyDrawingCommand(document, {
+        type: "ERASE_AT",
+        point: { x: 0.9, y: 0.9 },
+        radius: 0.01,
+      }),
+    ).toBe(document)
+    expect(applyDrawingCommand(emptyDrawingDocument, { type: "CLEAR" })).toBe(
+      emptyDrawingDocument,
+    )
+  })
+
+  it("clears every stroke immutably", () => {
+    const document = { strokes: [stroke] }
+    expect(applyDrawingCommand(document, { type: "CLEAR" })).toEqual({
+      strokes: [],
+    })
+    expect(document.strokes).toHaveLength(1)
+  })
+})

--- a/src/core/drawing/drawing-commands.ts
+++ b/src/core/drawing/drawing-commands.ts
@@ -1,0 +1,34 @@
+import type { DrawingDocument, NormalizedPoint, Stroke } from "./drawing-model"
+
+export type DrawingCommand =
+  | { type: "ADD_STROKE"; stroke: Stroke }
+  | { type: "ERASE_AT"; point: NormalizedPoint; radius: number }
+  | { type: "CLEAR" }
+
+function distance(a: NormalizedPoint, b: NormalizedPoint) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+function strokeTouches(stroke: Stroke, point: NormalizedPoint, radius: number) {
+  return stroke.points.some(
+    (strokePoint) => distance(strokePoint, point) <= radius + stroke.width / 2,
+  )
+}
+
+export function applyDrawingCommand(
+  document: DrawingDocument,
+  command: DrawingCommand,
+): DrawingDocument {
+  switch (command.type) {
+    case "ADD_STROKE":
+      return { strokes: [...document.strokes, command.stroke] }
+    case "ERASE_AT": {
+      const strokes = document.strokes.filter(
+        (stroke) => !strokeTouches(stroke, command.point, command.radius),
+      )
+      return strokes.length === document.strokes.length ? document : { strokes }
+    }
+    case "CLEAR":
+      return document.strokes.length === 0 ? document : { strokes: [] }
+  }
+}

--- a/src/core/drawing/drawing-history.test.ts
+++ b/src/core/drawing/drawing-history.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createDrawingHistory,
+  recordDrawing,
+  redoDrawing,
+  undoDrawing,
+} from "./drawing-history"
+import {
+  emptyDrawingDocument,
+  isNormalizedPoint,
+  type DrawingDocument,
+  type Stroke,
+} from "./drawing-model"
+
+const stroke: Stroke = {
+  id: "stroke-1",
+  tool: "pen",
+  color: "#111111",
+  width: 0.01,
+  points: [{ x: 0.25, y: 0.5 }],
+}
+
+function documentWith(...strokes: Stroke[]): DrawingDocument {
+  return { strokes }
+}
+
+describe("drawing model and history", () => {
+  it("defines normalized stroke points and drawing attributes", () => {
+    expect(isNormalizedPoint(stroke.points[0]!)).toBe(true)
+    expect(isNormalizedPoint({ x: 1.1, y: 0.5 })).toBe(false)
+    expect(stroke).toMatchObject({ tool: "pen", color: "#111111" })
+  })
+
+  it("undoes and redoes document states deterministically", () => {
+    const drawn = documentWith(stroke)
+    const history = recordDrawing(
+      createDrawingHistory(emptyDrawingDocument),
+      drawn,
+    )
+
+    expect(undoDrawing(history).present).toBe(emptyDrawingDocument)
+    expect(redoDrawing(undoDrawing(history)).present).toBe(drawn)
+  })
+
+  it("invalidates redo after a new action", () => {
+    const first = documentWith(stroke)
+    const undone = undoDrawing(
+      recordDrawing(createDrawingHistory(emptyDrawingDocument), first),
+    )
+    const replacement = documentWith({ ...stroke, id: "replacement" })
+
+    expect(recordDrawing(undone, replacement).future).toEqual([])
+  })
+
+  it("bounds retained history", () => {
+    let history = createDrawingHistory(emptyDrawingDocument, 2)
+    for (const id of ["one", "two", "three"]) {
+      history = recordDrawing(history, documentWith({ ...stroke, id }))
+    }
+    expect(history.past).toHaveLength(2)
+  })
+
+  it("ignores unavailable history operations and identical states", () => {
+    const history = createDrawingHistory(emptyDrawingDocument)
+    expect(undoDrawing(history)).toBe(history)
+    expect(redoDrawing(history)).toBe(history)
+    expect(recordDrawing(history, history.present)).toBe(history)
+  })
+
+  it("rejects invalid history limits", () => {
+    expect(() => createDrawingHistory(emptyDrawingDocument, 0)).toThrow(
+      "positive integer",
+    )
+  })
+})

--- a/src/core/drawing/drawing-history.ts
+++ b/src/core/drawing/drawing-history.ts
@@ -1,0 +1,53 @@
+import type { DrawingDocument } from "./drawing-model"
+
+export type DrawingHistory = {
+  past: readonly DrawingDocument[]
+  present: DrawingDocument
+  future: readonly DrawingDocument[]
+  limit: number
+}
+
+export function createDrawingHistory(
+  present: DrawingDocument,
+  limit = 50,
+): DrawingHistory {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("Drawing history limit must be a positive integer")
+  }
+  return { past: [], present, future: [], limit }
+}
+
+export function recordDrawing(
+  history: DrawingHistory,
+  next: DrawingDocument,
+): DrawingHistory {
+  if (next === history.present) return history
+  return {
+    ...history,
+    past: [...history.past, history.present].slice(-history.limit),
+    present: next,
+    future: [],
+  }
+}
+
+export function undoDrawing(history: DrawingHistory): DrawingHistory {
+  const previous = history.past.at(-1)
+  if (!previous) return history
+  return {
+    ...history,
+    past: history.past.slice(0, -1),
+    present: previous,
+    future: [history.present, ...history.future],
+  }
+}
+
+export function redoDrawing(history: DrawingHistory): DrawingHistory {
+  const next = history.future[0]
+  if (!next) return history
+  return {
+    ...history,
+    past: [...history.past, history.present].slice(-history.limit),
+    present: next,
+    future: history.future.slice(1),
+  }
+}

--- a/src/core/drawing/drawing-model.ts
+++ b/src/core/drawing/drawing-model.ts
@@ -1,0 +1,25 @@
+export type NormalizedPoint = {
+  x: number
+  y: number
+  pressure?: number
+}
+
+export type StrokeTool = "pen" | "eraser"
+
+export type Stroke = {
+  id: string
+  tool: StrokeTool
+  color: string
+  width: number
+  points: readonly NormalizedPoint[]
+}
+
+export type DrawingDocument = {
+  strokes: readonly Stroke[]
+}
+
+export const emptyDrawingDocument: DrawingDocument = { strokes: [] }
+
+export function isNormalizedPoint(point: NormalizedPoint) {
+  return point.x >= 0 && point.x <= 1 && point.y >= 0 && point.y <= 1
+}

--- a/src/core/drawing/two-layer-canvas-renderer.test.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.test.ts
@@ -17,6 +17,7 @@ function createContext() {
     lineTo: vi.fn(),
     lineWidth: 1,
     moveTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
     restore: vi.fn(),
     save: vi.fn(),
     setTransform: vi.fn(),
@@ -127,6 +128,30 @@ describe("TwoLayerCanvasRenderer", () => {
       0,
       Math.PI * 2,
     )
+  })
+
+  it("smooths sampled paths with quadratic midpoints", () => {
+    const harness = createHarness(1)
+    harness.renderer.resize(200, 100)
+    harness.renderer.setDocument({
+      strokes: [
+        {
+          ...stroke,
+          points: [
+            { x: 0.1, y: 0.2 },
+            { x: 0.4, y: 0.6 },
+            { x: 0.8, y: 0.4 },
+          ],
+        },
+      ],
+    })
+    harness.flush()
+
+    const curve = harness.persistentContext.quadraticCurveTo.mock.calls[0]
+    expect(curve?.[0]).toBeCloseTo(80)
+    expect(curve?.[1]).toBeCloseTo(60)
+    expect(curve?.[2]).toBeCloseTo(120)
+    expect(curve?.[3]).toBeCloseTo(50)
   })
 
   it("renders eraser strokes and ignores empty stroke geometry", () => {

--- a/src/core/drawing/two-layer-canvas-renderer.test.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { CanvasDrawingController } from "./canvas-drawing-controller"
+import type { Stroke } from "./drawing-model"
+import { TwoLayerCanvasRenderer } from "./two-layer-canvas-renderer"
+
+function createContext() {
+  return {
+    arc: vi.fn(),
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    fill: vi.fn(),
+    fillStyle: "",
+    globalCompositeOperation: "source-over",
+    lineCap: "butt",
+    lineJoin: "miter",
+    lineTo: vi.fn(),
+    lineWidth: 1,
+    moveTo: vi.fn(),
+    restore: vi.fn(),
+    save: vi.fn(),
+    setTransform: vi.fn(),
+    stroke: vi.fn(),
+    strokeStyle: "",
+  }
+}
+
+function createHarness(devicePixelRatio = 2) {
+  const persistentContext = createContext()
+  const interactionContext = createContext()
+  const persistentCanvas = {
+    getContext: () => persistentContext,
+    height: 0,
+    style: { height: "", width: "" },
+    width: 0,
+  } as unknown as HTMLCanvasElement
+  const interactionCanvas = {
+    getContext: () => interactionContext,
+    height: 0,
+    style: { height: "", width: "" },
+    width: 0,
+  } as unknown as HTMLCanvasElement
+  let scheduled: FrameRequestCallback | null = null
+  const cancelFrame = vi.fn()
+  const renderer = new TwoLayerCanvasRenderer(
+    persistentCanvas,
+    interactionCanvas,
+    {
+      devicePixelRatio: () => devicePixelRatio,
+      requestFrame: (callback) => {
+        scheduled = callback
+        return 1
+      },
+      cancelFrame,
+    },
+  )
+  const flush = () => {
+    const callback = scheduled
+    scheduled = null
+    if (callback) callback(0)
+  }
+  return {
+    cancelFrame,
+    flush,
+    interactionCanvas,
+    interactionContext,
+    persistentCanvas,
+    persistentContext,
+    renderer,
+  }
+}
+
+const stroke: Stroke = {
+  id: "stroke-1",
+  tool: "pen",
+  color: "#111111",
+  width: 0.01,
+  points: [
+    { x: 0.25, y: 0.5 },
+    { x: 0.75, y: 0.5 },
+  ],
+}
+
+describe("TwoLayerCanvasRenderer", () => {
+  it("sizes both layers for high-DPI output", () => {
+    const harness = createHarness(2)
+    harness.renderer.resize(300, 200)
+
+    expect(harness.persistentCanvas.width).toBe(600)
+    expect(harness.persistentCanvas.height).toBe(400)
+    expect(harness.interactionCanvas.width).toBe(600)
+    expect(harness.persistentContext.setTransform).toHaveBeenCalledWith(
+      2,
+      0,
+      0,
+      2,
+      0,
+      0,
+    )
+  })
+
+  it("replays normalized strokes after a resize", () => {
+    const harness = createHarness(1)
+    harness.renderer.resize(200, 100)
+    harness.renderer.setDocument({ strokes: [stroke] })
+    harness.flush()
+    expect(harness.persistentContext.moveTo).toHaveBeenLastCalledWith(50, 50)
+
+    harness.renderer.resize(400, 200)
+    harness.flush()
+    expect(harness.persistentContext.moveTo).toHaveBeenLastCalledWith(100, 100)
+    expect(harness.persistentContext.lineTo).toHaveBeenLastCalledWith(300, 100)
+  })
+
+  it("coalesces pointer and preview updates into one animation frame", () => {
+    const harness = createHarness(1)
+    harness.renderer.resize(200, 100)
+    harness.renderer.setPreviewStroke(stroke)
+    harness.renderer.setPointer({ x: 30, y: 40 })
+    harness.flush()
+
+    expect(harness.interactionContext.stroke).toHaveBeenCalledOnce()
+    expect(harness.interactionContext.arc).toHaveBeenCalledWith(
+      30,
+      40,
+      6,
+      0,
+      Math.PI * 2,
+    )
+  })
+
+  it("renders eraser strokes and ignores empty stroke geometry", () => {
+    const harness = createHarness(1)
+    harness.renderer.resize(100, 100)
+    harness.renderer.setDocument({
+      strokes: [
+        { ...stroke, tool: "eraser" },
+        { ...stroke, id: "empty", points: [] },
+      ],
+    })
+    harness.flush()
+
+    expect(harness.persistentContext.globalCompositeOperation).toBe(
+      "destination-out",
+    )
+    expect(harness.persistentContext.stroke).toHaveBeenCalledOnce()
+  })
+
+  it("clears the interaction layer when pointer and preview are absent", () => {
+    const harness = createHarness(0.5)
+    harness.renderer.resize(-10, -20)
+    harness.renderer.setPointer(null)
+    harness.renderer.setPreviewStroke(null)
+    harness.flush()
+
+    expect(harness.persistentCanvas.width).toBe(0)
+    expect(harness.interactionContext.arc).not.toHaveBeenCalled()
+  })
+
+  it("cancels a scheduled frame when disposed", () => {
+    const harness = createHarness()
+    harness.renderer.resize(100, 100)
+    harness.renderer.dispose()
+    harness.renderer.dispose()
+
+    expect(harness.cancelFrame).toHaveBeenCalledOnce()
+  })
+
+  it("rejects environments without two Canvas 2D contexts", () => {
+    const unavailable = {
+      getContext: () => null,
+    } as unknown as HTMLCanvasElement
+    expect(() => new TwoLayerCanvasRenderer(unavailable, unavailable)).toThrow(
+      "Canvas 2D support",
+    )
+  })
+})
+
+describe("CanvasDrawingController", () => {
+  it("commits and replays a stroke when tracking is lost", () => {
+    const harness = createHarness(1)
+    const controller = new CanvasDrawingController(harness.renderer)
+    controller.setBounds({ left: 100, top: 50, width: 400, height: 200 })
+
+    controller.handle({
+      version: 1,
+      type: "DRAW_START",
+      point: { x: 200, y: 100 },
+      timestampMs: 0,
+    })
+    controller.handle({
+      version: 1,
+      type: "DRAW_MOVE",
+      point: { x: 300, y: 150 },
+      timestampMs: 16,
+    })
+    controller.handle({
+      version: 1,
+      type: "TRACKING_LOST",
+      timestampMs: 32,
+    })
+
+    expect(controller.document.strokes[0]?.points).toEqual([
+      { x: 0.25, y: 0.25 },
+      { x: 0.5, y: 0.5 },
+    ])
+    controller.undo()
+    expect(controller.document.strokes).toEqual([])
+    controller.redo()
+    expect(controller.document.strokes).toHaveLength(1)
+  })
+
+  it("applies style, clamps points, and finishes explicitly", () => {
+    const harness = createHarness(1)
+    const controller = new CanvasDrawingController(harness.renderer)
+    controller.setBounds({ left: 10, top: 20, width: 100, height: 50 })
+    controller.setStyle({ tool: "eraser", color: "#ffffff", width: 0.04 })
+    controller.handle({
+      version: 1,
+      type: "POINTER_MOVE",
+      point: { x: 60, y: 45 },
+      timestampMs: 0,
+    })
+    controller.handle({
+      version: 1,
+      type: "DRAW_START",
+      point: { x: -100, y: 500 },
+      timestampMs: 1,
+    })
+    controller.handle({
+      version: 1,
+      type: "DRAW_END",
+      point: { x: 0, y: 0 },
+      timestampMs: 2,
+    })
+
+    expect(controller.document.strokes[0]).toMatchObject({
+      tool: "eraser",
+      color: "#ffffff",
+      width: 0.04,
+      points: [{ x: 0, y: 1 }],
+    })
+  })
+
+  it("safely ignores move and pause signals without an active stroke", () => {
+    const harness = createHarness(1)
+    const controller = new CanvasDrawingController(harness.renderer)
+    controller.handle({
+      version: 1,
+      type: "DRAW_MOVE",
+      point: { x: 1, y: 1 },
+      timestampMs: 0,
+    })
+    controller.handle({ version: 1, type: "PAUSE", timestampMs: 1 })
+
+    expect(controller.document.strokes).toEqual([])
+  })
+})

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -21,6 +21,7 @@ export class TwoLayerCanvasRenderer {
   readonly #cancelFrame: (handle: number) => void
   #document: DrawingDocument = emptyDrawingDocument
   #pointer: CanvasPoint | null = null
+  #previewStroke: Stroke | null = null
   #width = 0
   #height = 0
   #frameHandle: number | null = null
@@ -70,6 +71,11 @@ export class TwoLayerCanvasRenderer {
     this.requestRender()
   }
 
+  setPreviewStroke(stroke: Stroke | null) {
+    this.#previewStroke = stroke
+    this.requestRender()
+  }
+
   requestRender() {
     if (this.#frameHandle !== null) return
     this.#frameHandle = this.#requestFrame(() => {
@@ -110,6 +116,30 @@ export class TwoLayerCanvasRenderer {
     for (const stroke of this.#document.strokes) this.#renderStroke(stroke)
 
     this.#interactionContext.clearRect(0, 0, this.#width, this.#height)
+    if (this.#previewStroke) {
+      const [first, ...rest] = this.#previewStroke.points
+      if (first) {
+        this.#interactionContext.save()
+        this.#interactionContext.strokeStyle = this.#previewStroke.color
+        this.#interactionContext.lineWidth =
+          this.#previewStroke.width * Math.min(this.#width, this.#height)
+        this.#interactionContext.lineCap = "round"
+        this.#interactionContext.lineJoin = "round"
+        this.#interactionContext.beginPath()
+        this.#interactionContext.moveTo(
+          first.x * this.#width,
+          first.y * this.#height,
+        )
+        for (const point of rest) {
+          this.#interactionContext.lineTo(
+            point.x * this.#width,
+            point.y * this.#height,
+          )
+        }
+        this.#interactionContext.stroke()
+        this.#interactionContext.restore()
+      }
+    }
     if (!this.#pointer) return
     this.#interactionContext.beginPath()
     this.#interactionContext.arc(

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -42,8 +42,10 @@ export class TwoLayerCanvasRenderer {
     this.#interactionContext = interactionContext
     this.#devicePixelRatio =
       options.devicePixelRatio ?? (() => devicePixelRatio)
-    this.#requestFrame = options.requestFrame ?? requestAnimationFrame
-    this.#cancelFrame = options.cancelFrame ?? cancelAnimationFrame
+    this.#requestFrame =
+      options.requestFrame ?? ((callback) => requestAnimationFrame(callback))
+    this.#cancelFrame =
+      options.cancelFrame ?? ((handle) => cancelAnimationFrame(handle))
   }
 
   resize(width: number, height: number) {

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -106,8 +106,18 @@ export class TwoLayerCanvasRenderer {
     context.lineJoin = "round"
     context.beginPath()
     context.moveTo(first.x * this.#width, first.y * this.#height)
-    for (const point of rest) {
-      context.lineTo(point.x * this.#width, point.y * this.#height)
+    for (const [index, point] of rest.entries()) {
+      const next = rest[index + 1]
+      if (!next) {
+        context.lineTo(point.x * this.#width, point.y * this.#height)
+        continue
+      }
+      context.quadraticCurveTo(
+        point.x * this.#width,
+        point.y * this.#height,
+        ((point.x + next.x) / 2) * this.#width,
+        ((point.y + next.y) / 2) * this.#height,
+      )
     }
     context.stroke()
     context.restore()
@@ -132,10 +142,20 @@ export class TwoLayerCanvasRenderer {
           first.x * this.#width,
           first.y * this.#height,
         )
-        for (const point of rest) {
-          this.#interactionContext.lineTo(
+        for (const [index, point] of rest.entries()) {
+          const next = rest[index + 1]
+          if (!next) {
+            this.#interactionContext.lineTo(
+              point.x * this.#width,
+              point.y * this.#height,
+            )
+            continue
+          }
+          this.#interactionContext.quadraticCurveTo(
             point.x * this.#width,
             point.y * this.#height,
+            ((point.x + next.x) / 2) * this.#width,
+            ((point.y + next.y) / 2) * this.#height,
           )
         }
         this.#interactionContext.stroke()

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -1,0 +1,125 @@
+import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
+
+import type { DrawingDocument, Stroke } from "./drawing-model"
+import { emptyDrawingDocument } from "./drawing-model"
+
+type FrameScheduler = (callback: FrameRequestCallback) => number
+
+export type CanvasRendererOptions = {
+  devicePixelRatio?: () => number
+  requestFrame?: FrameScheduler
+  cancelFrame?: (handle: number) => void
+}
+
+export class TwoLayerCanvasRenderer {
+  readonly #persistentCanvas: HTMLCanvasElement
+  readonly #interactionCanvas: HTMLCanvasElement
+  readonly #persistentContext: CanvasRenderingContext2D
+  readonly #interactionContext: CanvasRenderingContext2D
+  readonly #devicePixelRatio: () => number
+  readonly #requestFrame: FrameScheduler
+  readonly #cancelFrame: (handle: number) => void
+  #document: DrawingDocument = emptyDrawingDocument
+  #pointer: CanvasPoint | null = null
+  #width = 0
+  #height = 0
+  #frameHandle: number | null = null
+
+  constructor(
+    persistentCanvas: HTMLCanvasElement,
+    interactionCanvas: HTMLCanvasElement,
+    options: CanvasRendererOptions = {},
+  ) {
+    const persistentContext = persistentCanvas.getContext("2d")
+    const interactionContext = interactionCanvas.getContext("2d")
+    if (!persistentContext || !interactionContext) {
+      throw new Error("DrawMotion requires Canvas 2D support")
+    }
+    this.#persistentCanvas = persistentCanvas
+    this.#interactionCanvas = interactionCanvas
+    this.#persistentContext = persistentContext
+    this.#interactionContext = interactionContext
+    this.#devicePixelRatio =
+      options.devicePixelRatio ?? (() => devicePixelRatio)
+    this.#requestFrame = options.requestFrame ?? requestAnimationFrame
+    this.#cancelFrame = options.cancelFrame ?? cancelAnimationFrame
+  }
+
+  resize(width: number, height: number) {
+    this.#width = Math.max(0, width)
+    this.#height = Math.max(0, height)
+    const ratio = Math.max(1, this.#devicePixelRatio())
+    for (const canvas of [this.#persistentCanvas, this.#interactionCanvas]) {
+      canvas.width = Math.round(this.#width * ratio)
+      canvas.height = Math.round(this.#height * ratio)
+      canvas.style.width = `${this.#width}px`
+      canvas.style.height = `${this.#height}px`
+    }
+    this.#persistentContext.setTransform(ratio, 0, 0, ratio, 0, 0)
+    this.#interactionContext.setTransform(ratio, 0, 0, ratio, 0, 0)
+    this.requestRender()
+  }
+
+  setDocument(document: DrawingDocument) {
+    this.#document = document
+    this.requestRender()
+  }
+
+  setPointer(point: CanvasPoint | null) {
+    this.#pointer = point
+    this.requestRender()
+  }
+
+  requestRender() {
+    if (this.#frameHandle !== null) return
+    this.#frameHandle = this.#requestFrame(() => {
+      this.#frameHandle = null
+      this.#render()
+    })
+  }
+
+  dispose() {
+    if (this.#frameHandle !== null) {
+      this.#cancelFrame(this.#frameHandle)
+      this.#frameHandle = null
+    }
+  }
+
+  #renderStroke(stroke: Stroke) {
+    const [first, ...rest] = stroke.points
+    if (!first) return
+    const context = this.#persistentContext
+    context.save()
+    context.globalCompositeOperation =
+      stroke.tool === "eraser" ? "destination-out" : "source-over"
+    context.strokeStyle = stroke.color
+    context.lineWidth = stroke.width * Math.min(this.#width, this.#height)
+    context.lineCap = "round"
+    context.lineJoin = "round"
+    context.beginPath()
+    context.moveTo(first.x * this.#width, first.y * this.#height)
+    for (const point of rest) {
+      context.lineTo(point.x * this.#width, point.y * this.#height)
+    }
+    context.stroke()
+    context.restore()
+  }
+
+  #render() {
+    this.#persistentContext.clearRect(0, 0, this.#width, this.#height)
+    for (const stroke of this.#document.strokes) this.#renderStroke(stroke)
+
+    this.#interactionContext.clearRect(0, 0, this.#width, this.#height)
+    if (!this.#pointer) return
+    this.#interactionContext.beginPath()
+    this.#interactionContext.arc(
+      this.#pointer.x,
+      this.#pointer.y,
+      6,
+      0,
+      Math.PI * 2,
+    )
+    this.#interactionContext.fillStyle = "#7c3aed"
+    this.#interactionContext.fill()
+  }
+}

--- a/src/core/gestures/gesture-classifier.test.ts
+++ b/src/core/gestures/gesture-classifier.test.ts
@@ -37,17 +37,17 @@ describe("classifyGesture", () => {
   })
 
   it("uses separate pinch entry and exit thresholds", () => {
-    const inDeadBand = handFromGestureFixture(withPinchRatio(0.36))
+    const inDeadBand = handFromGestureFixture(withPinchRatio(0.21))
 
     expect(classifyGesture(inDeadBand, "open-hand").kind).toBe("open-hand")
     expect(classifyGesture(inDeadBand, "pinch").kind).toBe("pinch")
   })
 
   it.each([
-    [0.3, "open-hand", "pinch"],
-    [0.301, "open-hand", "open-hand"],
-    [0.42, "pinch", "pinch"],
-    [0.421, "pinch", "open-hand"],
+    [0.18, "open-hand", "pinch"],
+    [0.181, "open-hand", "open-hand"],
+    [0.24, "pinch", "pinch"],
+    [0.241, "pinch", "open-hand"],
   ] as const)(
     "keeps ratio %s stable from %s",
     (ratio, previousKind, expected) => {

--- a/src/core/gestures/gesture-fixtures.test.ts
+++ b/src/core/gestures/gesture-fixtures.test.ts
@@ -40,11 +40,11 @@ describe("gesture classification fixtures", () => {
   })
 
   it("keeps the pinch fixture clearly below the open-hand ratio", () => {
-    expect(pinchRatio(pinchGestureLandmarks)).toBeLessThan(0.3)
+    expect(pinchRatio(pinchGestureLandmarks)).toBeLessThan(0.18)
     expect(pinchRatio(openHandGestureLandmarks)).toBeGreaterThan(0.5)
   })
 
-  it.each([0.29, 0.3, 0.42, 0.43])(
+  it.each([0.17, 0.18, 0.24, 0.25])(
     "creates exact non-regression poses around ratio %s",
     (ratio) => {
       expect(pinchRatio(withPinchRatio(ratio))).toBeCloseTo(ratio, 8)

--- a/src/core/gestures/gesture-pointer.test.ts
+++ b/src/core/gestures/gesture-pointer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  handFromGestureFixture,
+  pinchGestureLandmarks,
+} from "@/test/fixtures/gesture-landmarks"
+
+import { selectGesturePointer } from "./gesture-pointer"
+
+describe("selectGesturePointer", () => {
+  it("uses the pinch center instead of a jitter-prone single fingertip", () => {
+    const hand = handFromGestureFixture(pinchGestureLandmarks)
+    const thumb = hand.landmarks[4]!
+    const index = hand.landmarks[8]!
+
+    expect(selectGesturePointer(hand, "pinch")).toEqual({
+      x: (thumb.x + index.x) / 2,
+      y: (thumb.y + index.y) / 2,
+      z: (thumb.z + index.z) / 2,
+    })
+  })
+
+  it("keeps the index tip as the ordinary pointer", () => {
+    const hand = handFromGestureFixture(pinchGestureLandmarks)
+    expect(selectGesturePointer(hand, "open-hand")).toBe(hand.landmarks[8])
+  })
+
+  it("returns no pointer for missing hand geometry", () => {
+    expect(selectGesturePointer(null, "tracking-lost")).toBeNull()
+    expect(selectGesturePointer(handFromGestureFixture([]), "pinch")).toBeNull()
+  })
+})

--- a/src/core/gestures/gesture-pointer.ts
+++ b/src/core/gestures/gesture-pointer.ts
@@ -1,0 +1,32 @@
+import type { GestureKind } from "./gesture-classifier"
+import type {
+  NormalizedLandmark,
+  TrackedHand,
+} from "@/infrastructure/mediapipe/hand-tracker-port"
+
+function midpoint(
+  first: NormalizedLandmark,
+  second: NormalizedLandmark,
+): NormalizedLandmark {
+  return {
+    x: (first.x + second.x) / 2,
+    y: (first.y + second.y) / 2,
+    z: (first.z + second.z) / 2,
+  }
+}
+
+export function selectGesturePointer(
+  hand: TrackedHand | null,
+  gesture: GestureKind,
+): NormalizedLandmark | null {
+  if (!hand) return null
+  const indexTip = hand.landmarks[8]
+  if (!indexTip) return null
+
+  if (gesture === "pinch") {
+    const thumbTip = hand.landmarks[4]
+    return thumbTip ? midpoint(thumbTip, indexTip) : indexTip
+  }
+
+  return indexTip
+}

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -31,18 +31,18 @@ function classifySequence(ratios: number[], initial: GestureKind) {
 describe("gesture jitter and accidental activation resistance", () => {
   it("does not chatter while a pinched hand jitters inside the dead band", () => {
     expect(
-      classifySequence([0.29, 0.31, 0.38, 0.34, 0.41, 0.32], "open-hand"),
+      classifySequence([0.17, 0.19, 0.21, 0.2, 0.23, 0.19], "open-hand"),
     ).toEqual(["pinch", "pinch", "pinch", "pinch", "pinch", "pinch"])
   })
 
   it("does not enter pinch while an open hand jitters above entry", () => {
     expect(
-      classifySequence([0.31, 0.38, 0.33, 0.41, 0.305], "open-hand"),
+      classifySequence([0.19, 0.22, 0.2, 0.23, 0.185], "open-hand"),
     ).toEqual(["open-hand", "open-hand", "open-hand", "open-hand", "open-hand"])
   })
 
   it("requires crossing the exit boundary before releasing pinch", () => {
-    expect(classifySequence([0.41, 0.419, 0.43], "pinch")).toEqual([
+    expect(classifySequence([0.23, 0.239, 0.25], "pinch")).toEqual([
       "pinch",
       "pinch",
       "open-hand",

--- a/src/core/gestures/gesture-thresholds.ts
+++ b/src/core/gestures/gesture-thresholds.ts
@@ -2,9 +2,9 @@ export const GESTURE_THRESHOLDS = {
   /** Minimum tracker confidence before a hand may produce a gesture. */
   minimumHandConfidence: 0.65,
   /** Thumb-to-index distance, divided by palm size, required to enter pinch. */
-  pinchEnterRatio: 0.3,
+  pinchEnterRatio: 0.18,
   /** Larger release boundary that prevents chatter around pinch entry. */
-  pinchExitRatio: 0.42,
+  pinchExitRatio: 0.24,
   /** Fingertip must exceed its PIP-to-wrist distance by this factor. */
   fingerExtensionRatio: 1.12,
   /** Index through little finger count needed for an open hand. */

--- a/src/core/gestures/pointer-motion-filter.ts
+++ b/src/core/gestures/pointer-motion-filter.ts
@@ -9,7 +9,7 @@ export type PointerMotionFilterOptions = {
   timeConstantMs?: number
 }
 
-const DEFAULT_TIME_CONSTANT_MS = 45
+const DEFAULT_TIME_CONSTANT_MS = 70
 
 export class PointerMotionFilter {
   readonly #timeConstantMs: number

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -17,10 +17,13 @@ import {
   useHandTracking,
   type HandTrackerFactory,
 } from "@/features/camera/use-hand-tracking"
+import type { GestureKind } from "@/core/gestures/gesture-classifier"
+import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
 
 type CameraPreviewProps = {
   adapterFactory?: CameraAdapterFactory
   trackerFactory?: HandTrackerFactory
+  onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void
 }
 
 const trackingContent = {
@@ -73,6 +76,7 @@ const errorContent = {
 export function CameraPreview({
   adapterFactory,
   trackerFactory,
+  onGestureFrame,
 }: CameraPreviewProps) {
   const {
     devices,
@@ -88,7 +92,12 @@ export function CameraPreview({
     gesture,
     metrics,
     state: trackingState,
-  } = useHandTracking(state === "ready", videoRef, trackerFactory)
+  } = useHandTracking(
+    state === "ready",
+    videoRef,
+    trackerFactory,
+    onGestureFrame,
+  )
   const trackingStatus = trackingContent[trackingState]
   const error =
     state === "denied" ||

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -7,6 +7,7 @@ import {
 import type {
   HandTrackerMetrics,
   HandTrackerPort,
+  HandTrackingResult,
 } from "@/infrastructure/mediapipe/hand-tracker-port"
 import {
   HandTrackingSession,
@@ -30,11 +31,17 @@ export function useHandTracking(
   enabled: boolean,
   videoRef: RefObject<HTMLVideoElement | null>,
   trackerFactory: HandTrackerFactory = createTracker,
+  onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void,
 ) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
   const [gesture, setGesture] = useState<GestureKind>("tracking-lost")
   const [metrics, setMetrics] = useState<HandTrackerMetrics | null>(null)
+  const onGestureFrameRef = useRef(onGestureFrame)
+
+  useEffect(() => {
+    onGestureFrameRef.current = onGestureFrame
+  }, [onGestureFrame])
 
   useEffect(() => {
     if (!enabled) {
@@ -72,6 +79,7 @@ export function useHandTracking(
             previousGesture,
           )
           previousGesture = classification.kind
+          onGestureFrameRef.current?.(result, classification.kind)
           setGesture((current) =>
             current === classification.kind ? current : classification.kind,
           )

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -1,45 +1,67 @@
-import { useEffect, useRef } from "react"
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 
 import { CanvasDrawingController } from "@/core/drawing/canvas-drawing-controller"
 import { TwoLayerCanvasRenderer } from "@/core/drawing/two-layer-canvas-renderer"
 
-export function DrawingCanvas() {
-  const rootRef = useRef<HTMLDivElement>(null)
-  const persistentRef = useRef<HTMLCanvasElement>(null)
-  const interactionRef = useRef<HTMLCanvasElement>(null)
+import type { DrawingIntention } from "@/core/gestures/drawing-intentions"
 
-  useEffect(() => {
-    const root = rootRef.current
-    const persistent = persistentRef.current
-    const interaction = interactionRef.current
-    if (!root || !persistent || !interaction || !globalThis.ResizeObserver) {
-      return
-    }
-
-    const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
-    const controller = new CanvasDrawingController(renderer)
-    const observer = new ResizeObserver(([entry]) => {
-      if (!entry) return
-      const bounds = entry.contentRect
-      controller.setBounds({
-        left: bounds.left,
-        top: bounds.top,
-        width: bounds.width,
-        height: bounds.height,
-      })
-    })
-    observer.observe(root)
-
-    return () => {
-      observer.disconnect()
-      renderer.dispose()
-    }
-  }, [])
-
-  return (
-    <div ref={rootRef} className="drawing-canvas" aria-hidden="true">
-      <canvas ref={persistentRef} className="drawing-canvas__layer" />
-      <canvas ref={interactionRef} className="drawing-canvas__layer" />
-    </div>
-  )
+export type DrawingCanvasHandle = {
+  handleIntentions(intentions: readonly DrawingIntention[]): void
 }
+
+export const DrawingCanvas = forwardRef<DrawingCanvasHandle>(
+  function DrawingCanvas(_props, ref) {
+    const rootRef = useRef<HTMLDivElement>(null)
+    const persistentRef = useRef<HTMLCanvasElement>(null)
+    const interactionRef = useRef<HTMLCanvasElement>(null)
+    const controllerRef = useRef<CanvasDrawingController | null>(null)
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        handleIntentions(intentions) {
+          for (const intention of intentions)
+            controllerRef.current?.handle(intention)
+        },
+      }),
+      [],
+    )
+
+    useEffect(() => {
+      const root = rootRef.current
+      const persistent = persistentRef.current
+      const interaction = interactionRef.current
+      if (!root || !persistent || !interaction || !globalThis.ResizeObserver) {
+        return
+      }
+
+      const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
+      const controller = new CanvasDrawingController(renderer)
+      controllerRef.current = controller
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return
+        const bounds = root.getBoundingClientRect()
+        controller.setBounds({
+          left: bounds.left,
+          top: bounds.top,
+          width: bounds.width,
+          height: bounds.height,
+        })
+      })
+      observer.observe(root)
+
+      return () => {
+        observer.disconnect()
+        controllerRef.current = null
+        renderer.dispose()
+      }
+    }, [])
+
+    return (
+      <div ref={rootRef} className="drawing-canvas" aria-hidden="true">
+        <canvas ref={persistentRef} className="drawing-canvas__layer" />
+        <canvas ref={interactionRef} className="drawing-canvas__layer" />
+      </div>
+    )
+  },
+)

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react"
+
+import { CanvasDrawingController } from "@/core/drawing/canvas-drawing-controller"
+import { TwoLayerCanvasRenderer } from "@/core/drawing/two-layer-canvas-renderer"
+
+export function DrawingCanvas() {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const persistentRef = useRef<HTMLCanvasElement>(null)
+  const interactionRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const root = rootRef.current
+    const persistent = persistentRef.current
+    const interaction = interactionRef.current
+    if (!root || !persistent || !interaction || !globalThis.ResizeObserver) {
+      return
+    }
+
+    const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
+    const controller = new CanvasDrawingController(renderer)
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      const bounds = entry.contentRect
+      controller.setBounds({
+        left: bounds.left,
+        top: bounds.top,
+        width: bounds.width,
+        height: bounds.height,
+      })
+    })
+    observer.observe(root)
+
+    return () => {
+      observer.disconnect()
+      renderer.dispose()
+    }
+  }, [])
+
+  return (
+    <div ref={rootRef} className="drawing-canvas" aria-hidden="true">
+      <canvas ref={persistentRef} className="drawing-canvas__layer" />
+      <canvas ref={interactionRef} className="drawing-canvas__layer" />
+    </div>
+  )
+}

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -7,6 +7,7 @@ import {
   type GestureMachineState,
 } from "@/core/gestures/gesture-state-machine"
 import { PointerMotionFilter } from "@/core/gestures/pointer-motion-filter"
+import { selectGesturePointer } from "@/core/gestures/gesture-pointer"
 import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
@@ -40,19 +41,20 @@ export function WorkspaceShell() {
   const handleGestureFrame = useCallback(
     (result: HandTrackingResult, gesture: GestureKind) => {
       const bounds = stageRef.current?.getBoundingClientRect()
-      const indexTip = result.hands[0]?.landmarks[8]
+      const hand = result.hands[0] ?? null
+      const gesturePointer = selectGesturePointer(hand, gesture)
       if (!bounds) return
-      const mapped = indexTip
-        ? mapMirroredCameraPointToCanvas(indexTip, bounds)
-        : null
       const filtered = pointerFilterRef.current.update(
-        mapped,
+        gesturePointer,
         result.timestampMs,
         gesture !== "uncertain" && gesture !== "tracking-lost",
       )
+      const mapped = filtered.point
+        ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
+        : null
       const transition = transitionGestureState(gestureStateRef.current, {
         gesture,
-        point: filtered.reliable ? filtered.point : null,
+        point: filtered.reliable ? mapped : null,
         timestampMs: result.timestampMs,
       })
       gestureStateRef.current = transition.state

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -4,6 +4,7 @@ import { CameraPreview } from "@/features/camera/camera-preview"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
 import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
 import { TopBar } from "@/features/toolbar/top-bar"
+import { DrawingCanvas } from "@/features/workspace/drawing-canvas"
 
 import "./workspace.css"
 
@@ -32,6 +33,7 @@ export function WorkspaceShell() {
           aria-label="Toile de dessin vide"
           className="drawing-stage"
         >
+          <DrawingCanvas />
           <div className="sr-only" aria-live="polite">
             {toolNames[activeTool]} sélectionné — simulation
           </div>

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,10 +1,23 @@
-import { useState } from "react"
+import { useCallback, useRef, useState } from "react"
+
+import type { GestureKind } from "@/core/gestures/gesture-classifier"
+import {
+  initialGestureMachineState,
+  transitionGestureState,
+  type GestureMachineState,
+} from "@/core/gestures/gesture-state-machine"
+import { PointerMotionFilter } from "@/core/gestures/pointer-motion-filter"
+import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
 import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
 import { TopBar } from "@/features/toolbar/top-bar"
-import { DrawingCanvas } from "@/features/workspace/drawing-canvas"
+import {
+  DrawingCanvas,
+  type DrawingCanvasHandle,
+} from "@/features/workspace/drawing-canvas"
+import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
 
 import "./workspace.css"
 
@@ -17,6 +30,36 @@ const toolNames: Record<DrawingTool, string> = {
 export function WorkspaceShell() {
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
   const [coachStep, setCoachStep] = useState(0)
+  const stageRef = useRef<HTMLElement>(null)
+  const drawingRef = useRef<DrawingCanvasHandle>(null)
+  const pointerFilterRef = useRef(new PointerMotionFilter())
+  const gestureStateRef = useRef<GestureMachineState>(
+    initialGestureMachineState,
+  )
+
+  const handleGestureFrame = useCallback(
+    (result: HandTrackingResult, gesture: GestureKind) => {
+      const bounds = stageRef.current?.getBoundingClientRect()
+      const indexTip = result.hands[0]?.landmarks[8]
+      if (!bounds) return
+      const mapped = indexTip
+        ? mapMirroredCameraPointToCanvas(indexTip, bounds)
+        : null
+      const filtered = pointerFilterRef.current.update(
+        mapped,
+        result.timestampMs,
+        gesture !== "uncertain" && gesture !== "tracking-lost",
+      )
+      const transition = transitionGestureState(gestureStateRef.current, {
+        gesture,
+        point: filtered.reliable ? filtered.point : null,
+        timestampMs: result.timestampMs,
+      })
+      gestureStateRef.current = transition.state
+      drawingRef.current?.handleIntentions(transition.intentions)
+    },
+    [],
+  )
 
   return (
     <div className="workspace-shell">
@@ -28,16 +71,17 @@ export function WorkspaceShell() {
         <ToolRail activeTool={activeTool} onToolChange={setActiveTool} />
 
         <section
+          ref={stageRef}
           id="drawing-canvas"
           tabIndex={-1}
           aria-label="Toile de dessin vide"
           className="drawing-stage"
         >
-          <DrawingCanvas />
+          <DrawingCanvas ref={drawingRef} />
           <div className="sr-only" aria-live="polite">
             {toolNames[activeTool]} sélectionné — simulation
           </div>
-          <CameraPreview />
+          <CameraPreview onGestureFrame={handleGestureFrame} />
           <GestureCoach step={coachStep} onStepChange={setCoachStep} />
         </section>
       </main>

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -26,6 +26,18 @@
   outline-offset: 2px;
 }
 
+.drawing-canvas,
+.drawing-canvas__layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.drawing-canvas {
+  pointer-events: none;
+}
+
 .tool-rail {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Résumé
- définit le modèle de traits normalisés et l’historique borné
- rend et rejoue les traits sur deux couches Canvas haute densité
- connecte MediaPipe aux intentions puis au contrôleur Canvas hors React
- stabilise le tracé et resserre le cycle d’activation/libération du pincement

## Vérifications
- [x] pnpm validate`n- [x] 131 tests
- [x] couverture contractuelle de core/drawing`n- [x] contrôle navigateur sans erreur console
- [x] dessin réel par webcam validé
- [x] perte de main observée sans liaison parasite
- [x] redimensionnement et rejeu couverts automatiquement
- [x] aucune dépendance ajoutée

## Suivi UX
- [x] la zone confortable de mouvement sera calibrée dans le lot 7