### PR TITLE
feat: teach DrawMotion in three validated gestures

### DIFF
--- a/src/core/drawing/canvas-drawing-controller.ts
+++ b/src/core/drawing/canvas-drawing-controller.ts
@@ -11,10 +11,12 @@ import {
 } from "./drawing-history"
 import {
   emptyDrawingDocument,
+  type AssistedPrimitive,
   type NormalizedPoint,
   type Stroke,
   type StrokeTool,
 } from "./drawing-model"
+import { assistStroke, type StrokeAssistanceMode } from "./stroke-assistance"
 import { TwoLayerCanvasRenderer } from "./two-layer-canvas-renderer"
 
 export type DrawingStyle = {
@@ -23,13 +25,21 @@ export type DrawingStyle = {
   width: number
 }
 
+export type StrokeAssistanceFeedback = {
+  strokeId: string
+  primitive: AssistedPrimitive
+  confidence: number
+}
+
 export class CanvasDrawingController {
   readonly #renderer: TwoLayerCanvasRenderer
   #history: DrawingHistory
   #bounds: CanvasBounds = { left: 0, top: 0, width: 1, height: 1 }
   #style: DrawingStyle = { tool: "pen", color: "#111111", width: 0.008 }
+  #assistanceMode: StrokeAssistanceMode = "stabilized"
   #activeStroke: Stroke | null = null
   #nextStrokeId = 1
+  #onAssistance: ((feedback: StrokeAssistanceFeedback) => void) | null = null
 
   constructor(renderer: TwoLayerCanvasRenderer, historyLimit = 50) {
     this.#renderer = renderer
@@ -48,6 +58,16 @@ export class CanvasDrawingController {
 
   setStyle(style: DrawingStyle) {
     this.#style = style
+  }
+
+  setAssistanceMode(mode: StrokeAssistanceMode) {
+    this.#assistanceMode = mode
+  }
+
+  setAssistanceListener(
+    listener: ((feedback: StrokeAssistanceFeedback) => void) | null,
+  ) {
+    this.#onAssistance = listener
   }
 
   handle(intention: DrawingIntention) {
@@ -98,16 +118,45 @@ export class CanvasDrawingController {
     this.#renderer.setDocument(this.#history.present)
   }
 
+  revertAssistance(strokeId: string) {
+    const strokeIndex = this.#history.present.strokes.findIndex(
+      (stroke) => stroke.id === strokeId && stroke.assistance,
+    )
+    if (strokeIndex < 0) return false
+    const stroke = this.#history.present.strokes[strokeIndex]
+    if (!stroke?.assistance) return false
+    const { assistance, ...unassistedStroke } = stroke
+    const strokes = [...this.#history.present.strokes]
+    strokes[strokeIndex] = {
+      ...unassistedStroke,
+      points: assistance.originalPoints,
+    }
+    this.#history = recordDrawing(this.#history, { strokes })
+    this.#renderer.setDocument(this.#history.present)
+    return true
+  }
+
   #finishStroke() {
     if (!this.#activeStroke) return
+    const assisted = assistStroke(
+      this.#activeStroke,
+      this.#bounds,
+      this.#assistanceMode,
+    )
     const next = applyDrawingCommand(this.#history.present, {
       type: "ADD_STROKE",
-      stroke: this.#activeStroke,
+      stroke: assisted.stroke,
     })
     this.#history = recordDrawing(this.#history, next)
     this.#activeStroke = null
     this.#renderer.setPreviewStroke(null)
     this.#renderer.setDocument(this.#history.present)
+    if (assisted.correction) {
+      this.#onAssistance?.({
+        strokeId: assisted.stroke.id,
+        ...assisted.correction,
+      })
+    }
   }
 
   #toLocalPoint(point: { x: number; y: number }) {

--- a/src/core/drawing/drawing-model.ts
+++ b/src/core/drawing/drawing-model.ts
@@ -6,12 +6,21 @@ export type NormalizedPoint = {
 
 export type StrokeTool = "pen" | "eraser"
 
+export type AssistedPrimitive = "line" | "circle" | "ellipse" | "rectangle"
+
+export type StrokeAssistance = {
+  primitive: AssistedPrimitive
+  confidence: number
+  originalPoints: readonly NormalizedPoint[]
+}
+
 export type Stroke = {
   id: string
   tool: StrokeTool
   color: string
   width: number
   points: readonly NormalizedPoint[]
+  assistance?: StrokeAssistance
 }
 
 export type DrawingDocument = {

--- a/src/core/drawing/stroke-assistance.test.ts
+++ b/src/core/drawing/stroke-assistance.test.ts
@@ -33,6 +33,35 @@ function noisyEllipse(radiusX: number, radiusY: number) {
   })
 }
 
+function noisyRectangle() {
+  const corners = [
+    { x: 0.2, y: 0.2 },
+    { x: 0.75, y: 0.2 },
+    { x: 0.75, y: 0.7 },
+    { x: 0.2, y: 0.7 },
+    { x: 0.2, y: 0.2 },
+  ]
+  return corners
+    .flatMap((corner, index) => {
+      const next = corners[index + 1]
+      if (!next) return []
+      return Array.from({ length: 16 }, (_, sample) => {
+        const progress = sample / 16
+        return {
+          x:
+            corner.x +
+            (next.x - corner.x) * progress +
+            Math.sin((index * 16 + sample) * 1.8) * 0.001,
+          y:
+            corner.y +
+            (next.y - corner.y) * progress +
+            Math.cos((index * 16 + sample) * 1.4) * 0.001,
+        }
+      })
+    })
+    .concat(corners[0]!)
+}
+
 describe("assistStroke", () => {
   it("keeps free drawing free while regularizing its samples", () => {
     const original = stroke([
@@ -73,6 +102,13 @@ describe("assistStroke", () => {
     expect(circle.correction?.primitive).toBe("circle")
     expect(circle.stroke.points).toHaveLength(65)
     expect(ellipse.correction?.primitive).toBe("ellipse")
+  })
+
+  it("recognizes a closed rectangle without confusing it with an ellipse", () => {
+    const result = assistStroke(stroke(noisyRectangle()), bounds, "shapes")
+
+    expect(result.correction?.primitive).toBe("rectangle")
+    expect(result.stroke.points).toHaveLength(5)
   })
 
   it("does not force an ambiguous organic stroke into a primitive", () => {

--- a/src/core/drawing/stroke-assistance.test.ts
+++ b/src/core/drawing/stroke-assistance.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+
+import type { NormalizedPoint, Stroke } from "./drawing-model"
+import { assistStroke } from "./stroke-assistance"
+
+const bounds = { left: 0, top: 0, width: 1000, height: 600 }
+
+function stroke(points: readonly NormalizedPoint[]): Stroke {
+  return {
+    id: "stroke-1",
+    tool: "pen",
+    color: "#111111",
+    width: 0.008,
+    points,
+  }
+}
+
+function noisyLine() {
+  return Array.from({ length: 30 }, (_, index) => ({
+    x: 0.15 + index * 0.02,
+    y: 0.3 + Math.sin(index * 1.7) * 0.002,
+  }))
+}
+
+function noisyEllipse(radiusX: number, radiusY: number) {
+  return Array.from({ length: 81 }, (_, index) => {
+    const angle = (index / 80) * Math.PI * 2
+    const noise = Math.sin(index * 2.1) * 0.003
+    return {
+      x: 0.5 + Math.cos(angle) * (radiusX + noise),
+      y: 0.5 + Math.sin(angle) * (radiusY + noise),
+    }
+  })
+}
+
+describe("assistStroke", () => {
+  it("keeps free drawing free while regularizing its samples", () => {
+    const original = stroke([
+      { x: 0.1, y: 0.1 },
+      { x: 0.101, y: 0.1 },
+      { x: 0.2, y: 0.1 },
+    ])
+    const result = assistStroke(original, bounds, "free")
+
+    expect(result.correction).toBeNull()
+    expect(result.stroke.points[0]).toEqual(original.points[0])
+    expect(result.stroke.points.at(-1)).toEqual(original.points.at(-1))
+    expect(result.stroke.points.length).toBeGreaterThan(original.points.length)
+  })
+
+  it("beautifies a confident line and preserves the original points", () => {
+    const original = stroke(noisyLine())
+    const result = assistStroke(original, bounds, "shapes")
+
+    expect(result.correction?.primitive).toBe("line")
+    expect(result.correction?.confidence).toBeGreaterThanOrEqual(0.86)
+    expect(result.stroke.points).toHaveLength(2)
+    expect(result.stroke.assistance?.originalPoints).toEqual(original.points)
+  })
+
+  it("recognizes circles and ellipses in pixel space", () => {
+    const circle = assistStroke(
+      stroke(noisyEllipse(0.16, 0.27)),
+      bounds,
+      "shapes",
+    )
+    const ellipse = assistStroke(
+      stroke(noisyEllipse(0.24, 0.18)),
+      bounds,
+      "shapes",
+    )
+
+    expect(circle.correction?.primitive).toBe("circle")
+    expect(circle.stroke.points).toHaveLength(65)
+    expect(ellipse.correction?.primitive).toBe("ellipse")
+  })
+
+  it("does not force an ambiguous organic stroke into a primitive", () => {
+    const result = assistStroke(
+      stroke([
+        { x: 0.1, y: 0.1 },
+        { x: 0.2, y: 0.3 },
+        { x: 0.25, y: 0.14 },
+        { x: 0.38, y: 0.42 },
+        { x: 0.5, y: 0.2 },
+      ]),
+      bounds,
+      "shapes",
+    )
+
+    expect(result.correction).toBeNull()
+    expect(result.stroke.assistance).toBeUndefined()
+  })
+
+  it("never reshapes eraser strokes", () => {
+    const eraser = { ...stroke(noisyLine()), tool: "eraser" as const }
+    expect(assistStroke(eraser, bounds, "shapes")).toEqual({
+      stroke: eraser,
+      correction: null,
+    })
+  })
+})

--- a/src/core/drawing/stroke-assistance.test.ts
+++ b/src/core/drawing/stroke-assistance.test.ts
@@ -62,6 +62,56 @@ function noisyRectangle() {
     .concat(corners[0]!)
 }
 
+function openCircle() {
+  return Array.from({ length: 64 }, (_, index) => {
+    const angle = 0.15 + (index / 63) * Math.PI * 1.68
+    return {
+      x: 0.5 + Math.cos(angle) * 0.16 + Math.sin(index * 1.9) * 0.004,
+      y: 0.5 + Math.sin(angle) * 0.27 + Math.cos(index * 1.6) * 0.004,
+    }
+  })
+}
+
+function imperfectRectangle() {
+  const corners = [
+    { x: 0.22, y: 0.22 },
+    { x: 0.72, y: 0.24 },
+    { x: 0.76, y: 0.68 },
+    { x: 0.19, y: 0.66 },
+    { x: 0.24, y: 0.25 },
+  ]
+  return corners.flatMap((corner, index) => {
+    const next = corners[index + 1]
+    if (!next) return []
+    return Array.from({ length: 14 }, (_, sample) => {
+      const progress = sample / 14
+      return {
+        x:
+          corner.x +
+          (next.x - corner.x) * progress +
+          Math.sin((index * 14 + sample) * 1.3) * 0.004,
+        y:
+          corner.y +
+          (next.y - corner.y) * progress +
+          Math.cos((index * 14 + sample) * 1.7) * 0.004,
+      }
+    })
+  })
+}
+
+function hookedLine() {
+  return [
+    { x: 0.12, y: 0.6 },
+    { x: 0.15, y: 0.56 },
+    ...Array.from({ length: 36 }, (_, index) => ({
+      x: 0.16 + index * 0.019,
+      y: 0.55 + Math.sin(index * 0.55) * 0.009,
+    })),
+    { x: 0.87, y: 0.58 },
+    { x: 0.84, y: 0.62 },
+  ]
+}
+
 describe("assistStroke", () => {
   it("keeps free drawing free while regularizing its samples", () => {
     const original = stroke([
@@ -109,6 +159,29 @@ describe("assistStroke", () => {
 
     expect(result.correction?.primitive).toBe("rectangle")
     expect(result.stroke.points).toHaveLength(5)
+  })
+
+  it("magnetically closes a clearly circular stroke with a realistic gap", () => {
+    const original = stroke(openCircle())
+    const result = assistStroke(original, bounds, "shapes")
+
+    expect(result.correction?.primitive).toBe("circle")
+    expect(result.stroke.points[0]).toEqual(result.stroke.points.at(-1))
+    expect(result.stroke.assistance?.originalPoints).toEqual(original.points)
+  })
+
+  it("beautifies a hand-drawn quadrilateral with uneven corners", () => {
+    const result = assistStroke(stroke(imperfectRectangle()), bounds, "shapes")
+
+    expect(result.correction?.primitive).toBe("rectangle")
+    expect(result.stroke.points).toHaveLength(5)
+  })
+
+  it("recognizes a mostly straight gesture despite small endpoint hooks", () => {
+    const result = assistStroke(stroke(hookedLine()), bounds, "shapes")
+
+    expect(result.correction?.primitive).toBe("line")
+    expect(result.stroke.points).toHaveLength(2)
   })
 
   it("does not force an ambiguous organic stroke into a primitive", () => {

--- a/src/core/drawing/stroke-assistance.ts
+++ b/src/core/drawing/stroke-assistance.ts
@@ -108,6 +108,106 @@ function signedArea(points: readonly Point2D[]) {
   }, 0)
 }
 
+function rectangleCandidate(
+  points: readonly Point2D[],
+): PrimitiveCandidate | null {
+  const first = points[0]
+  const last = points.at(-1)
+  if (!first || !last || points.length < 12) return null
+  const diagonal = boundsDiagonal(points)
+  if (
+    diagonal < MIN_PRIMITIVE_SIZE_PX ||
+    distance(first, last) / diagonal > 0.14
+  ) {
+    return null
+  }
+
+  const center = points.reduce(
+    (sum, point) => ({ x: sum.x + point.x, y: sum.y + point.y }),
+    { x: 0, y: 0 },
+  )
+  center.x /= points.length
+  center.y /= points.length
+  const covariance = points.reduce(
+    (sum, point) => {
+      const x = point.x - center.x
+      const y = point.y - center.y
+      return { xx: sum.xx + x * x, xy: sum.xy + x * y, yy: sum.yy + y * y }
+    },
+    { xx: 0, xy: 0, yy: 0 },
+  )
+  const rotation =
+    0.5 * Math.atan2(2 * covariance.xy, covariance.xx - covariance.yy)
+  const cosRotation = Math.cos(rotation)
+  const sinRotation = Math.sin(rotation)
+  const localPoints = points.map((point) => ({
+    x: (point.x - center.x) * cosRotation + (point.y - center.y) * sinRotation,
+    y: -(point.x - center.x) * sinRotation + (point.y - center.y) * cosRotation,
+  }))
+  const minX = Math.min(...localPoints.map((point) => point.x))
+  const maxX = Math.max(...localPoints.map((point) => point.x))
+  const minY = Math.min(...localPoints.map((point) => point.y))
+  const maxY = Math.max(...localPoints.map((point) => point.y))
+  const width = maxX - minX
+  const height = maxY - minY
+  if (Math.min(width, height) < MIN_PRIMITIVE_SIZE_PX / 2) return null
+
+  const edgeCounts = [0, 0, 0, 0]
+  const meanEdgeError =
+    localPoints.reduce((sum, point) => {
+      const distances = [
+        Math.abs(point.x - minX),
+        Math.abs(point.x - maxX),
+        Math.abs(point.y - minY),
+        Math.abs(point.y - maxY),
+      ]
+      const edgeDistance = Math.min(...distances)
+      const edgeIndex = distances.indexOf(edgeDistance)
+      edgeCounts[edgeIndex] = (edgeCounts[edgeIndex] ?? 0) + 1
+      return sum + edgeDistance
+    }, 0) / points.length
+  const normalizedError = meanEdgeError / Math.hypot(width, height)
+  const perimeterError = Math.abs(
+    pathLength(points) / (2 * (width + height)) - 1,
+  )
+  const visitsEveryEdge = edgeCounts.every(
+    (count) => count / points.length >= 0.08,
+  )
+  if (normalizedError > 0.028 || perimeterError > 0.22 || !visitsEveryEdge) {
+    return null
+  }
+
+  const toWorld = (point: Point2D) => ({
+    x: center.x + point.x * cosRotation - point.y * sinRotation,
+    y: center.y + point.x * sinRotation + point.y * cosRotation,
+  })
+  const corners = [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
+    { x: minX, y: maxY },
+  ].map(toWorld)
+  if (signedArea(points) < 0) corners.reverse()
+  const startIndex = corners.reduce(
+    (bestIndex, corner, index) =>
+      distance(corner, first) < distance(corners[bestIndex]!, first)
+        ? index
+        : bestIndex,
+    0,
+  )
+  const orderedCorners = Array.from(
+    { length: 4 },
+    (_, index) => corners[(startIndex + index) % corners.length]!,
+  )
+  orderedCorners.push({ ...orderedCorners[0]! })
+
+  return {
+    primitive: "rectangle",
+    confidence: clampUnit(1 - normalizedError / 0.25 - perimeterError / 0.8),
+    points: orderedCorners,
+  }
+}
+
 function sampleEllipse(
   center: Point2D,
   radiusX: number,
@@ -241,6 +341,7 @@ export function assistStroke(
 
   const candidates = [
     lineCandidate(centerline),
+    rectangleCandidate(centerline),
     closedPrimitiveCandidate(centerline),
   ].filter((candidate): candidate is PrimitiveCandidate => candidate !== null)
   const candidate = candidates.sort((a, b) => b.confidence - a.confidence)[0]

--- a/src/core/drawing/stroke-assistance.ts
+++ b/src/core/drawing/stroke-assistance.ts
@@ -25,7 +25,7 @@ export type StrokeAssistanceResult = {
 
 const SAMPLE_SPACING_PX = 3
 const MIN_PRIMITIVE_SIZE_PX = 28
-const AUTO_CORRECTION_CONFIDENCE = 0.86
+const AUTO_CORRECTION_CONFIDENCE = 0.48
 
 type PrimitiveCandidate = StrokeCorrection & {
   points: Point2D[]
@@ -89,10 +89,10 @@ function lineCandidate(points: readonly Point2D[]): PrimitiveCandidate | null {
   const normalizedError =
     Math.sqrt(squaredError / points.length) / Math.max(endDistance, 1)
   const efficiency = endDistance / length
-  if (normalizedError > 0.035 || efficiency < 0.88) return null
+  if (normalizedError > 0.06 || efficiency < 0.82) return null
 
   const confidence = clampUnit(
-    0.55 * (1 - normalizedError / 0.035) + 0.45 * ((efficiency - 0.88) / 0.12),
+    0.7 * (1 - normalizedError / 0.12) + 0.3 * ((efficiency - 0.75) / 0.25),
   )
   return {
     primitive: "line",
@@ -117,7 +117,7 @@ function rectangleCandidate(
   const diagonal = boundsDiagonal(points)
   if (
     diagonal < MIN_PRIMITIVE_SIZE_PX ||
-    distance(first, last) / diagonal > 0.14
+    distance(first, last) / diagonal > 0.24
   ) {
     return null
   }
@@ -173,7 +173,7 @@ function rectangleCandidate(
   const visitsEveryEdge = edgeCounts.every(
     (count) => count / points.length >= 0.08,
   )
-  if (normalizedError > 0.028 || perimeterError > 0.22 || !visitsEveryEdge) {
+  if (normalizedError > 0.045 || perimeterError > 0.3 || !visitsEveryEdge) {
     return null
   }
 
@@ -226,7 +226,7 @@ function sampleEllipse(
     (startPoint.y - center.y) * cosRotation
   const startAngle = Math.atan2(localStartY / radiusY, localStartX / radiusX)
   const direction = clockwise ? 1 : -1
-  return Array.from({ length: 65 }, (_, index) => {
+  const samples = Array.from({ length: 65 }, (_, index) => {
     const angle = startAngle + direction * (index / 64) * Math.PI * 2
     const localX = Math.cos(angle) * radiusX
     const localY = Math.sin(angle) * radiusY
@@ -235,6 +235,8 @@ function sampleEllipse(
       y: center.y + localX * sinRotation + localY * cosRotation,
     }
   })
+  samples[samples.length - 1] = { ...samples[0]! }
+  return samples
 }
 
 function closedPrimitiveCandidate(
@@ -291,13 +293,26 @@ function closedPrimitiveCandidate(
     (majorRadius + minorRadius) *
     (1 + (3 * h) / (10 + Math.sqrt(4 - 3 * h)))
   const coverageError = Math.abs(pathLength(points) / circumference - 1)
-  if (closure > 0.32 || radialError > 0.13 || coverageError > 0.3) return null
+  if (closure > 1.1 || radialError > 0.16 || coverageError > 0.35) return null
 
   const confidence = clampUnit(
-    1 - closure / 1.2 - radialError / 0.8 - coverageError / 1.2,
+    0.1 * (1 - closure / 1.2) +
+      0.6 * (1 - radialError / 0.2) +
+      0.3 * (1 - coverageError / 0.4),
   )
   const axisRatio = majorRadius / minorRadius
-  const primitive: AssistedPrimitive = axisRatio < 1.16 ? "circle" : "ellipse"
+  const spanX =
+    Math.max(...points.map((point) => point.x)) -
+    Math.min(...points.map((point) => point.x))
+  const spanY =
+    Math.max(...points.map((point) => point.y)) -
+    Math.min(...points.map((point) => point.y))
+  const boundsRatio =
+    Math.max(spanX, spanY) / Math.max(1, Math.min(spanX, spanY))
+  const primitive: AssistedPrimitive =
+    axisRatio < 1.16 || (axisRatio < 1.35 && boundsRatio < 1.18)
+      ? "circle"
+      : "ellipse"
   const circleRadius = (radiusX + radiusY) / 2
   const fittedRadiusX = primitive === "circle" ? circleRadius : radiusX
   const fittedRadiusY = primitive === "circle" ? circleRadius : radiusY

--- a/src/core/drawing/stroke-assistance.ts
+++ b/src/core/drawing/stroke-assistance.ts
@@ -1,0 +1,266 @@
+import type { CanvasBounds } from "@/core/geometry/coordinate-mapping"
+
+import type {
+  AssistedPrimitive,
+  NormalizedPoint,
+  Stroke,
+} from "./drawing-model"
+import {
+  resamplePointsByDistance,
+  smoothPoints,
+  type Point2D,
+} from "./stroke-resampling"
+
+export type StrokeAssistanceMode = "free" | "stabilized" | "shapes"
+
+export type StrokeCorrection = {
+  primitive: AssistedPrimitive
+  confidence: number
+}
+
+export type StrokeAssistanceResult = {
+  stroke: Stroke
+  correction: StrokeCorrection | null
+}
+
+const SAMPLE_SPACING_PX = 3
+const MIN_PRIMITIVE_SIZE_PX = 28
+const AUTO_CORRECTION_CONFIDENCE = 0.86
+
+type PrimitiveCandidate = StrokeCorrection & {
+  points: Point2D[]
+}
+
+function clampUnit(value: number) {
+  return Math.min(1, Math.max(0, value))
+}
+
+function toPixels(points: readonly NormalizedPoint[], bounds: CanvasBounds) {
+  return points.map((point) => ({
+    x: point.x * bounds.width,
+    y: point.y * bounds.height,
+  }))
+}
+
+function toNormalized(points: readonly Point2D[], bounds: CanvasBounds) {
+  return points.map((point) => ({
+    x: clampUnit(point.x / Math.max(1, bounds.width)),
+    y: clampUnit(point.y / Math.max(1, bounds.height)),
+  }))
+}
+
+function distance(a: Point2D, b: Point2D) {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+function pathLength(points: readonly Point2D[]) {
+  return points.slice(1).reduce((length, point, index) => {
+    const previous = points[index]
+    return previous ? length + distance(previous, point) : length
+  }, 0)
+}
+
+function boundsDiagonal(points: readonly Point2D[]) {
+  const xs = points.map((point) => point.x)
+  const ys = points.map((point) => point.y)
+  return Math.hypot(
+    Math.max(...xs) - Math.min(...xs),
+    Math.max(...ys) - Math.min(...ys),
+  )
+}
+
+function lineCandidate(points: readonly Point2D[]): PrimitiveCandidate | null {
+  const first = points[0]
+  const last = points.at(-1)
+  if (!first || !last) return null
+  const length = pathLength(points)
+  const endDistance = distance(first, last)
+  if (endDistance < MIN_PRIMITIVE_SIZE_PX || length === 0) return null
+
+  const direction = {
+    x: (last.x - first.x) / endDistance,
+    y: (last.y - first.y) / endDistance,
+  }
+  const squaredError = points.reduce((sum, point) => {
+    const perpendicular =
+      (point.x - first.x) * -direction.y + (point.y - first.y) * direction.x
+    return sum + perpendicular * perpendicular
+  }, 0)
+  const normalizedError =
+    Math.sqrt(squaredError / points.length) / Math.max(endDistance, 1)
+  const efficiency = endDistance / length
+  if (normalizedError > 0.035 || efficiency < 0.88) return null
+
+  const confidence = clampUnit(
+    0.55 * (1 - normalizedError / 0.035) + 0.45 * ((efficiency - 0.88) / 0.12),
+  )
+  return {
+    primitive: "line",
+    confidence,
+    points: [{ ...first }, { ...last }],
+  }
+}
+
+function signedArea(points: readonly Point2D[]) {
+  return points.reduce((area, point, index) => {
+    const next = points[(index + 1) % points.length]
+    return next ? area + point.x * next.y - next.x * point.y : area
+  }, 0)
+}
+
+function sampleEllipse(
+  center: Point2D,
+  radiusX: number,
+  radiusY: number,
+  rotation: number,
+  startPoint: Point2D,
+  clockwise: boolean,
+) {
+  const cosRotation = Math.cos(rotation)
+  const sinRotation = Math.sin(rotation)
+  const localStartX =
+    (startPoint.x - center.x) * cosRotation +
+    (startPoint.y - center.y) * sinRotation
+  const localStartY =
+    -(startPoint.x - center.x) * sinRotation +
+    (startPoint.y - center.y) * cosRotation
+  const startAngle = Math.atan2(localStartY / radiusY, localStartX / radiusX)
+  const direction = clockwise ? 1 : -1
+  return Array.from({ length: 65 }, (_, index) => {
+    const angle = startAngle + direction * (index / 64) * Math.PI * 2
+    const localX = Math.cos(angle) * radiusX
+    const localY = Math.sin(angle) * radiusY
+    return {
+      x: center.x + localX * cosRotation - localY * sinRotation,
+      y: center.y + localX * sinRotation + localY * cosRotation,
+    }
+  })
+}
+
+function closedPrimitiveCandidate(
+  points: readonly Point2D[],
+): PrimitiveCandidate | null {
+  const first = points[0]
+  const last = points.at(-1)
+  if (!first || !last || points.length < 12) return null
+  const diagonal = boundsDiagonal(points)
+  if (diagonal < MIN_PRIMITIVE_SIZE_PX) return null
+
+  const center = points.reduce(
+    (sum, point) => ({ x: sum.x + point.x, y: sum.y + point.y }),
+    { x: 0, y: 0 },
+  )
+  center.x /= points.length
+  center.y /= points.length
+  const covariance = points.reduce(
+    (sum, point) => {
+      const x = point.x - center.x
+      const y = point.y - center.y
+      return { xx: sum.xx + x * x, xy: sum.xy + x * y, yy: sum.yy + y * y }
+    },
+    { xx: 0, xy: 0, yy: 0 },
+  )
+  covariance.xx /= points.length
+  covariance.xy /= points.length
+  covariance.yy /= points.length
+  const rotation =
+    0.5 * Math.atan2(2 * covariance.xy, covariance.xx - covariance.yy)
+  const trace = covariance.xx + covariance.yy
+  const delta = Math.hypot(covariance.xx - covariance.yy, 2 * covariance.xy)
+  const radiusX = Math.sqrt(Math.max(1, trace + delta))
+  const radiusY = Math.sqrt(Math.max(1, trace - delta))
+  const majorRadius = Math.max(radiusX, radiusY)
+  const minorRadius = Math.min(radiusX, radiusY)
+  if (minorRadius < MIN_PRIMITIVE_SIZE_PX / 4) return null
+
+  const cosRotation = Math.cos(rotation)
+  const sinRotation = Math.sin(rotation)
+  const radialError =
+    points.reduce((sum, point) => {
+      const localX =
+        (point.x - center.x) * cosRotation + (point.y - center.y) * sinRotation
+      const localY =
+        -(point.x - center.x) * sinRotation + (point.y - center.y) * cosRotation
+      const radius = Math.hypot(localX / radiusX, localY / radiusY)
+      return sum + Math.abs(radius - 1)
+    }, 0) / points.length
+  const closure = distance(first, last) / majorRadius
+  const h = ((majorRadius - minorRadius) / (majorRadius + minorRadius)) ** 2
+  const circumference =
+    Math.PI *
+    (majorRadius + minorRadius) *
+    (1 + (3 * h) / (10 + Math.sqrt(4 - 3 * h)))
+  const coverageError = Math.abs(pathLength(points) / circumference - 1)
+  if (closure > 0.32 || radialError > 0.13 || coverageError > 0.3) return null
+
+  const confidence = clampUnit(
+    1 - closure / 1.2 - radialError / 0.8 - coverageError / 1.2,
+  )
+  const axisRatio = majorRadius / minorRadius
+  const primitive: AssistedPrimitive = axisRatio < 1.16 ? "circle" : "ellipse"
+  const circleRadius = (radiusX + radiusY) / 2
+  const fittedRadiusX = primitive === "circle" ? circleRadius : radiusX
+  const fittedRadiusY = primitive === "circle" ? circleRadius : radiusY
+  return {
+    primitive,
+    confidence,
+    points: sampleEllipse(
+      center,
+      fittedRadiusX,
+      fittedRadiusY,
+      primitive === "circle" ? 0 : rotation,
+      first,
+      signedArea(points) > 0,
+    ),
+  }
+}
+
+function prepareCenterline(
+  points: readonly NormalizedPoint[],
+  bounds: CanvasBounds,
+  mode: StrokeAssistanceMode,
+) {
+  const sampled = resamplePointsByDistance(
+    toPixels(points, bounds),
+    SAMPLE_SPACING_PX,
+  )
+  return mode === "free" ? sampled : smoothPoints(sampled, 2)
+}
+
+export function assistStroke(
+  stroke: Stroke,
+  bounds: CanvasBounds,
+  mode: StrokeAssistanceMode,
+): StrokeAssistanceResult {
+  if (stroke.points.length < 2 || stroke.tool === "eraser") {
+    return { stroke, correction: null }
+  }
+  const centerline = prepareCenterline(stroke.points, bounds, mode)
+  const stabilized = { ...stroke, points: toNormalized(centerline, bounds) }
+  if (mode !== "shapes") return { stroke: stabilized, correction: null }
+
+  const candidates = [
+    lineCandidate(centerline),
+    closedPrimitiveCandidate(centerline),
+  ].filter((candidate): candidate is PrimitiveCandidate => candidate !== null)
+  const candidate = candidates.sort((a, b) => b.confidence - a.confidence)[0]
+  if (!candidate || candidate.confidence < AUTO_CORRECTION_CONFIDENCE) {
+    return { stroke: stabilized, correction: null }
+  }
+
+  const correction: StrokeCorrection = {
+    primitive: candidate.primitive,
+    confidence: candidate.confidence,
+  }
+  return {
+    correction,
+    stroke: {
+      ...stroke,
+      points: toNormalized(candidate.points, bounds),
+      assistance: {
+        ...correction,
+        originalPoints: stroke.points.map((point) => ({ ...point })),
+      },
+    },
+  }
+}

--- a/src/core/drawing/stroke-resampling.test.ts
+++ b/src/core/drawing/stroke-resampling.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import { resamplePointsByDistance, smoothPoints } from "./stroke-resampling"
+
+describe("resamplePointsByDistance", () => {
+  it("regularizes uneven samples and preserves both endpoints", () => {
+    const result = resamplePointsByDistance(
+      [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      3,
+    )
+
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+      { x: 6, y: 0 },
+      { x: 9, y: 0 },
+      { x: 10, y: 0 },
+    ])
+  })
+
+  it("rejects invalid spacing and safely handles empty geometry", () => {
+    expect(resamplePointsByDistance([], 2)).toEqual([])
+    expect(() => resamplePointsByDistance([], 0)).toThrow("greater than zero")
+  })
+})
+
+describe("smoothPoints", () => {
+  it("reduces an isolated wobble without moving the endpoints", () => {
+    const result = smoothPoints(
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 2 },
+        { x: 2, y: 0 },
+      ],
+      1,
+    )
+
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+      { x: 2, y: 0 },
+    ])
+  })
+})

--- a/src/core/drawing/stroke-resampling.ts
+++ b/src/core/drawing/stroke-resampling.ts
@@ -1,0 +1,82 @@
+import type { NormalizedPoint } from "./drawing-model"
+
+export type Point2D = Pick<NormalizedPoint, "x" | "y">
+
+function distance(a: Point2D, b: Point2D) {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+function interpolate(a: Point2D, b: Point2D, ratio: number): Point2D {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+  }
+}
+
+/**
+ * Places samples at a stable arc-length interval while preserving both ends.
+ * This prevents camera frame rate variations from changing the rendered curve.
+ */
+export function resamplePointsByDistance(
+  points: readonly Point2D[],
+  spacing: number,
+): Point2D[] {
+  if (!Number.isFinite(spacing) || spacing <= 0) {
+    throw new Error("Stroke sample spacing must be greater than zero")
+  }
+  const first = points[0]
+  if (!first) return []
+  if (points.length === 1) return [{ ...first }]
+
+  const samples: Point2D[] = [{ ...first }]
+  let previous = { ...first }
+  let distanceSinceSample = 0
+
+  for (const point of points.slice(1)) {
+    let segmentStart = previous
+    let segmentLength = distance(segmentStart, point)
+    if (segmentLength === 0) continue
+
+    while (distanceSinceSample + segmentLength >= spacing) {
+      const remaining = spacing - distanceSinceSample
+      const sample = interpolate(segmentStart, point, remaining / segmentLength)
+      samples.push(sample)
+      segmentStart = sample
+      segmentLength = distance(segmentStart, point)
+      distanceSinceSample = 0
+    }
+
+    distanceSinceSample += segmentLength
+    previous = { ...point }
+  }
+
+  const last = points.at(-1)
+  const sampledLast = samples.at(-1)
+  if (last && sampledLast && distance(sampledLast, last) > spacing * 0.1) {
+    samples.push({ ...last })
+  }
+  return samples
+}
+
+/** A small endpoint-preserving low-pass pass for the finalized centerline. */
+export function smoothPoints(
+  points: readonly Point2D[],
+  passes = 1,
+): Point2D[] {
+  if (passes < 1 || points.length < 3)
+    return points.map((point) => ({ ...point }))
+  let smoothed = points.map((point) => ({ ...point }))
+
+  for (let pass = 0; pass < passes; pass += 1) {
+    smoothed = smoothed.map((point, index, current) => {
+      const previous = current[index - 1]
+      const next = current[index + 1]
+      if (!previous || !next) return { ...point }
+      return {
+        x: (previous.x + point.x * 2 + next.x) / 4,
+        y: (previous.y + point.y * 2 + next.y) / 4,
+      }
+    })
+  }
+  return smoothed
+}

--- a/src/core/drawing/two-layer-canvas-renderer.test.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.test.ts
@@ -245,10 +245,10 @@ describe("CanvasDrawingController", () => {
       timestampMs: 32,
     })
 
-    expect(controller.document.strokes[0]?.points).toEqual([
-      { x: 0.25, y: 0.25 },
-      { x: 0.5, y: 0.5 },
-    ])
+    const points = controller.document.strokes[0]?.points
+    expect(points?.[0]).toEqual({ x: 0.25, y: 0.25 })
+    expect(points?.at(-1)).toEqual({ x: 0.5, y: 0.5 })
+    expect(points?.length).toBeGreaterThan(2)
     controller.undo()
     expect(controller.document.strokes).toEqual([])
     controller.redo()
@@ -299,5 +299,42 @@ describe("CanvasDrawingController", () => {
     controller.handle({ version: 1, type: "PAUSE", timestampMs: 1 })
 
     expect(controller.document.strokes).toEqual([])
+  })
+
+  it("applies confident shape assistance and can restore the original stroke", () => {
+    const harness = createHarness(1)
+    const controller = new CanvasDrawingController(harness.renderer)
+    const feedback = vi.fn()
+    controller.setBounds({ left: 0, top: 0, width: 1000, height: 600 })
+    controller.setAssistanceMode("shapes")
+    controller.setAssistanceListener(feedback)
+
+    for (let index = 0; index < 25; index += 1) {
+      const intention = {
+        version: 1 as const,
+        type: index === 0 ? ("DRAW_START" as const) : ("DRAW_MOVE" as const),
+        point: { x: 100 + index * 20, y: 200 + Math.sin(index) },
+        timestampMs: index * 16,
+      }
+      controller.handle(intention)
+    }
+    controller.handle({
+      version: 1,
+      type: "DRAW_END",
+      point: { x: 580, y: 200 },
+      timestampMs: 400,
+    })
+
+    const assisted = controller.document.strokes[0]
+    expect(assisted?.points).toHaveLength(2)
+    expect(assisted?.assistance?.primitive).toBe("line")
+    expect(feedback).toHaveBeenCalledWith(
+      expect.objectContaining({ strokeId: "stroke-1", primitive: "line" }),
+    )
+
+    expect(controller.revertAssistance("stroke-1")).toBe(true)
+    expect(controller.document.strokes[0]?.points).toHaveLength(25)
+    expect(controller.document.strokes[0]?.assistance).toBeUndefined()
+    expect(controller.revertAssistance("stroke-1")).toBe(false)
   })
 })

--- a/src/core/drawing/two-layer-canvas-renderer.test.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.test.ts
@@ -130,6 +130,26 @@ describe("TwoLayerCanvasRenderer", () => {
     )
   })
 
+  it("renders ink on the first drawing point without waiting for movement", () => {
+    const harness = createHarness(1)
+    harness.renderer.resize(200, 100)
+    harness.renderer.setPreviewStroke({
+      ...stroke,
+      points: [{ x: 0.25, y: 0.5 }],
+    })
+    harness.flush()
+
+    expect(harness.interactionContext.arc).toHaveBeenCalledWith(
+      50,
+      50,
+      0.5,
+      0,
+      Math.PI * 2,
+    )
+    expect(harness.interactionContext.fill).toHaveBeenCalledOnce()
+    expect(harness.interactionContext.stroke).not.toHaveBeenCalled()
+  })
+
   it("smooths sampled paths with quadratic midpoints", () => {
     const harness = createHarness(1)
     harness.renderer.resize(200, 100)

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -93,17 +93,38 @@ export class TwoLayerCanvasRenderer {
     }
   }
 
-  #renderStroke(stroke: Stroke) {
+  #renderStroke(
+    context: CanvasRenderingContext2D,
+    stroke: Stroke,
+    applyEraserComposite: boolean,
+  ) {
     const [first, ...rest] = stroke.points
     if (!first) return
-    const context = this.#persistentContext
     context.save()
     context.globalCompositeOperation =
-      stroke.tool === "eraser" ? "destination-out" : "source-over"
+      applyEraserComposite && stroke.tool === "eraser"
+        ? "destination-out"
+        : "source-over"
     context.strokeStyle = stroke.color
     context.lineWidth = stroke.width * Math.min(this.#width, this.#height)
     context.lineCap = "round"
     context.lineJoin = "round"
+
+    if (rest.length === 0) {
+      context.beginPath()
+      context.arc(
+        first.x * this.#width,
+        first.y * this.#height,
+        context.lineWidth / 2,
+        0,
+        Math.PI * 2,
+      )
+      context.fillStyle = stroke.color
+      context.fill()
+      context.restore()
+      return
+    }
+
     context.beginPath()
     context.moveTo(first.x * this.#width, first.y * this.#height)
     for (const [index, point] of rest.entries()) {
@@ -125,42 +146,13 @@ export class TwoLayerCanvasRenderer {
 
   #render() {
     this.#persistentContext.clearRect(0, 0, this.#width, this.#height)
-    for (const stroke of this.#document.strokes) this.#renderStroke(stroke)
+    for (const stroke of this.#document.strokes) {
+      this.#renderStroke(this.#persistentContext, stroke, true)
+    }
 
     this.#interactionContext.clearRect(0, 0, this.#width, this.#height)
     if (this.#previewStroke) {
-      const [first, ...rest] = this.#previewStroke.points
-      if (first) {
-        this.#interactionContext.save()
-        this.#interactionContext.strokeStyle = this.#previewStroke.color
-        this.#interactionContext.lineWidth =
-          this.#previewStroke.width * Math.min(this.#width, this.#height)
-        this.#interactionContext.lineCap = "round"
-        this.#interactionContext.lineJoin = "round"
-        this.#interactionContext.beginPath()
-        this.#interactionContext.moveTo(
-          first.x * this.#width,
-          first.y * this.#height,
-        )
-        for (const [index, point] of rest.entries()) {
-          const next = rest[index + 1]
-          if (!next) {
-            this.#interactionContext.lineTo(
-              point.x * this.#width,
-              point.y * this.#height,
-            )
-            continue
-          }
-          this.#interactionContext.quadraticCurveTo(
-            point.x * this.#width,
-            point.y * this.#height,
-            ((point.x + next.x) / 2) * this.#width,
-            ((point.y + next.y) / 2) * this.#height,
-          )
-        }
-        this.#interactionContext.stroke()
-        this.#interactionContext.restore()
-      }
+      this.#renderStroke(this.#interactionContext, this.#previewStroke, false)
     }
     if (!this.#pointer) return
     this.#interactionContext.beginPath()

--- a/src/core/geometry/coordinate-mapping.ts
+++ b/src/core/geometry/coordinate-mapping.ts
@@ -12,6 +12,27 @@ export type CanvasPoint = {
   y: number
 }
 
+export type CameraMappingRegion = {
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+export const COMFORTABLE_CAMERA_REGION: CameraMappingRegion = {
+  left: 0.12,
+  right: 0.88,
+  top: 0.1,
+  bottom: 0.9,
+}
+
+const FULL_CAMERA_REGION: CameraMappingRegion = {
+  left: 0,
+  right: 1,
+  top: 0,
+  bottom: 1,
+}
+
 function clampUnit(value: number) {
   return Math.min(1, Math.max(0, value))
 }
@@ -19,9 +40,16 @@ function clampUnit(value: number) {
 export function mapMirroredCameraPointToCanvas(
   point: Pick<NormalizedLandmark, "x" | "y">,
   bounds: CanvasBounds,
+  region: CameraMappingRegion = FULL_CAMERA_REGION,
 ): CanvasPoint {
+  const normalizedX = clampUnit(
+    (point.x - region.left) / (region.right - region.left),
+  )
+  const normalizedY = clampUnit(
+    (point.y - region.top) / (region.bottom - region.top),
+  )
   return {
-    x: bounds.left + (1 - clampUnit(point.x)) * bounds.width,
-    y: bounds.top + clampUnit(point.y) * bounds.height,
+    x: bounds.left + (1 - normalizedX) * bounds.width,
+    y: bounds.top + normalizedY * bounds.height,
   }
 }

--- a/src/core/geometry/coordinate-mapping.ts
+++ b/src/core/geometry/coordinate-mapping.ts
@@ -19,13 +19,6 @@ export type CameraMappingRegion = {
   bottom: number
 }
 
-export const COMFORTABLE_CAMERA_REGION: CameraMappingRegion = {
-  left: 0.12,
-  right: 0.88,
-  top: 0.1,
-  bottom: 0.9,
-}
-
 const FULL_CAMERA_REGION: CameraMappingRegion = {
   left: 0,
   right: 1,

--- a/src/core/gestures/gesture-classifier.test.ts
+++ b/src/core/gestures/gesture-classifier.test.ts
@@ -30,10 +30,10 @@ describe("classifyGesture", () => {
     )
   })
 
-  it("rejects a low-confidence hand", () => {
+  it("does not confuse handedness confidence with tracking quality", () => {
     expect(
-      classifyGesture(handFromGestureFixture(pinchGestureLandmarks, 0.64)).kind,
-    ).toBe("uncertain")
+      classifyGesture(handFromGestureFixture(pinchGestureLandmarks, 0.1)).kind,
+    ).toBe("pinch")
   })
 
   it("uses separate pinch entry and exit thresholds", () => {

--- a/src/core/gestures/gesture-classifier.ts
+++ b/src/core/gestures/gesture-classifier.ts
@@ -10,7 +10,6 @@ export type GestureKind =
 
 export type GestureClassification = {
   kind: GestureKind
-  confidence: number
   pinchRatio: number | null
   extendedFingerCount: number
 }
@@ -70,7 +69,6 @@ export function classifyGesture(
   if (!hand || hand.landmarks.length < 21) {
     return {
       kind: "tracking-lost",
-      confidence: 0,
       pinchRatio: null,
       extendedFingerCount: 0,
     }
@@ -78,13 +76,20 @@ export function classifyGesture(
 
   const pinchRatio = measurePinchRatio(hand.landmarks)
   const extendedFingerCount = countExtendedFingers(hand.landmarks)
-  if (
-    hand.confidence < GESTURE_THRESHOLDS.minimumHandConfidence ||
-    pinchRatio === null
-  ) {
+  if (pinchRatio === null) {
     return {
       kind: "uncertain",
-      confidence: hand.confidence,
+      pinchRatio,
+      extendedFingerCount,
+    }
+  }
+
+  const isContinuingPinch =
+    previousKind === "pinch" &&
+    pinchRatio <= GESTURE_THRESHOLDS.pinchExitRatio + Number.EPSILON * 16
+  if (isContinuingPinch) {
+    return {
+      kind: "pinch",
       pinchRatio,
       extendedFingerCount,
     }
@@ -93,20 +98,14 @@ export function classifyGesture(
   if (extendedFingerCount <= GESTURE_THRESHOLDS.fistMaximumExtendedFingers) {
     return {
       kind: "fist",
-      confidence: hand.confidence,
       pinchRatio,
       extendedFingerCount,
     }
   }
 
-  const pinchBoundary =
-    previousKind === "pinch"
-      ? GESTURE_THRESHOLDS.pinchExitRatio
-      : GESTURE_THRESHOLDS.pinchEnterRatio
-  if (pinchRatio <= pinchBoundary + Number.EPSILON * 16) {
+  if (pinchRatio <= GESTURE_THRESHOLDS.pinchEnterRatio + Number.EPSILON * 16) {
     return {
       kind: "pinch",
-      confidence: hand.confidence,
       pinchRatio,
       extendedFingerCount,
     }
@@ -117,7 +116,6 @@ export function classifyGesture(
   ) {
     return {
       kind: "open-hand",
-      confidence: hand.confidence,
       pinchRatio,
       extendedFingerCount,
     }
@@ -125,7 +123,6 @@ export function classifyGesture(
 
   return {
     kind: "uncertain",
-    confidence: hand.confidence,
     pinchRatio,
     extendedFingerCount,
   }

--- a/src/core/gestures/gesture-classifier.ts
+++ b/src/core/gestures/gesture-classifier.ts
@@ -4,6 +4,7 @@ import type {
 } from "@/infrastructure/mediapipe/hand-tracker-port"
 
 import { GESTURE_THRESHOLDS } from "./gesture-thresholds"
+import { measurePinchRatio } from "./pinch-detector"
 
 export type GestureKind =
   "pinch" | "open-hand" | "fist" | "uncertain" | "tracking-lost"
@@ -15,8 +16,6 @@ export type GestureClassification = {
 }
 
 const WRIST = 0
-const THUMB_TIP = 4
-const MIDDLE_MCP = 9
 const FINGER_JOINTS = [
   { pip: 6, tip: 8 },
   { pip: 10, tip: 12 },
@@ -50,18 +49,6 @@ function countExtendedFingers(landmarks: NormalizedLandmark[]) {
   }, 0)
 }
 
-function measurePinchRatio(landmarks: NormalizedLandmark[]) {
-  const wrist = landmarkAt(landmarks, WRIST)
-  const thumbTip = landmarkAt(landmarks, THUMB_TIP)
-  const indexTip = landmarkAt(landmarks, 8)
-  const middleMcp = landmarkAt(landmarks, MIDDLE_MCP)
-  if (!wrist || !thumbTip || !indexTip || !middleMcp) return null
-
-  const palmSize = distance(wrist, middleMcp)
-  if (palmSize <= Number.EPSILON) return null
-  return distance(thumbTip, indexTip) / palmSize
-}
-
 export function classifyGesture(
   hand: TrackedHand | null,
   previousKind: GestureKind = "tracking-lost",
@@ -74,7 +61,7 @@ export function classifyGesture(
     }
   }
 
-  const pinchRatio = measurePinchRatio(hand.landmarks)
+  const pinchRatio = measurePinchRatio(hand)
   const extendedFingerCount = countExtendedFingers(hand.landmarks)
   if (pinchRatio === null) {
     return {

--- a/src/core/gestures/gesture-pointer.test.ts
+++ b/src/core/gestures/gesture-pointer.test.ts
@@ -8,25 +8,13 @@ import {
 import { selectGesturePointer } from "./gesture-pointer"
 
 describe("selectGesturePointer", () => {
-  it("uses the pinch center instead of a jitter-prone single fingertip", () => {
+  it("keeps the index tip as the pointer through a pinch", () => {
     const hand = handFromGestureFixture(pinchGestureLandmarks)
-    const thumb = hand.landmarks[4]!
-    const index = hand.landmarks[8]!
-
-    expect(selectGesturePointer(hand, "pinch")).toEqual({
-      x: (thumb.x + index.x) / 2,
-      y: (thumb.y + index.y) / 2,
-      z: (thumb.z + index.z) / 2,
-    })
-  })
-
-  it("keeps the index tip as the ordinary pointer", () => {
-    const hand = handFromGestureFixture(pinchGestureLandmarks)
-    expect(selectGesturePointer(hand, "open-hand")).toBe(hand.landmarks[8])
+    expect(selectGesturePointer(hand)).toBe(hand.landmarks[8])
   })
 
   it("returns no pointer for missing hand geometry", () => {
-    expect(selectGesturePointer(null, "tracking-lost")).toBeNull()
-    expect(selectGesturePointer(handFromGestureFixture([]), "pinch")).toBeNull()
+    expect(selectGesturePointer(null)).toBeNull()
+    expect(selectGesturePointer(handFromGestureFixture([]))).toBeNull()
   })
 })

--- a/src/core/gestures/gesture-pointer.ts
+++ b/src/core/gestures/gesture-pointer.ts
@@ -1,32 +1,11 @@
-import type { GestureKind } from "./gesture-classifier"
 import type {
   NormalizedLandmark,
   TrackedHand,
 } from "@/infrastructure/mediapipe/hand-tracker-port"
 
-function midpoint(
-  first: NormalizedLandmark,
-  second: NormalizedLandmark,
-): NormalizedLandmark {
-  return {
-    x: (first.x + second.x) / 2,
-    y: (first.y + second.y) / 2,
-    z: (first.z + second.z) / 2,
-  }
-}
-
 export function selectGesturePointer(
   hand: TrackedHand | null,
-  gesture: GestureKind,
 ): NormalizedLandmark | null {
   if (!hand) return null
-  const indexTip = hand.landmarks[8]
-  if (!indexTip) return null
-
-  if (gesture === "pinch") {
-    const thumbTip = hand.landmarks[4]
-    return thumbTip ? midpoint(thumbTip, indexTip) : indexTip
-  }
-
-  return indexTip
+  return hand.landmarks[8] ?? null
 }

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -175,8 +175,40 @@ describe("gesture jitter and accidental activation resistance", () => {
   })
 
   it("rejects an invalid pointer smoothing time constant", () => {
-    expect(() => new PointerMotionFilter({ timeConstantMs: 0 })).toThrow(
+    expect(() => new PointerMotionFilter({ minCutoffHz: 0 })).toThrow(
       "greater than zero",
+    )
+  })
+
+  it("never bridges a bottom-to-top jump after tracking ambiguity", () => {
+    const filter = new PointerMotionFilter()
+    let state = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      point: { x: 0.5, y: 0.85 },
+      timestampMs: 0,
+    }).state
+    state = transitionGestureState(state, {
+      gesture: "uncertain",
+      point: null,
+      timestampMs: 16,
+    }).state
+
+    filter.update({ x: 0.5, y: 0.85 }, 0)
+    filter.update(null, 16)
+    const jump = filter.update({ x: 0.5, y: 0.1 }, 32)
+    const transition = transitionGestureState(state, {
+      gesture: "pinch",
+      point: jump.reliable ? jump.point : null,
+      timestampMs: 32,
+      continuous: !jump.discontinuity,
+    })
+
+    expect(transition.intentions.map(({ type }) => type)).toEqual([
+      "DRAW_END",
+      "TRACKING_LOST",
+    ])
+    expect(transition.intentions.map(({ type }) => type)).not.toContain(
+      "DRAW_MOVE",
     )
   })
 })

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -14,6 +14,7 @@ import {
   initialGestureMachineState,
   transitionGestureState,
 } from "./gesture-state-machine"
+import { PinchDetector } from "./pinch-detector"
 import { PointerMotionFilter } from "./pointer-motion-filter"
 
 function classifySequence(ratios: number[], initial: GestureKind) {
@@ -172,6 +173,52 @@ describe("gesture jitter and accidental activation resistance", () => {
     )
     expect(intentionTypes.filter((type) => type === "DRAW_END")).toHaveLength(1)
     expect(state.mode).toBe("paused")
+  })
+
+  it("keeps a circular stroke active while hand rotation loosens the pinch", () => {
+    const ratios = [0.15, 0.15, 0.28, 0.3, 0.32, 0.29, 0.27, 0.29]
+    const points = [
+      { x: 50, y: 20 },
+      { x: 71, y: 29 },
+      { x: 80, y: 50 },
+      { x: 71, y: 71 },
+      { x: 50, y: 80 },
+      { x: 29, y: 71 },
+      { x: 20, y: 50 },
+      { x: 50, y: 20 },
+    ]
+    const detector = new PinchDetector()
+    let state = initialGestureMachineState
+    const intentionTypes: string[] = []
+
+    ratios.forEach((ratio, index) => {
+      const timestampMs = index * 50
+      const pinch = detector.update(
+        handFromGestureFixture(withPinchRatio(ratio)),
+        true,
+        timestampMs,
+      )
+      const transition = transitionGestureState(state, {
+        gesture: pinch.phase === "released" ? "open-hand" : "pinch",
+        pinchPhase: pinch.phase,
+        point: points[index]!,
+        timestampMs,
+      })
+      state = transition.state
+      intentionTypes.push(...transition.intentions.map(({ type }) => type))
+    })
+
+    expect(intentionTypes.filter((type) => type === "DRAW_START")).toHaveLength(
+      1,
+    )
+    expect(intentionTypes.filter((type) => type === "DRAW_MOVE")).toHaveLength(
+      6,
+    )
+    expect(intentionTypes).not.toContain("DRAW_END")
+    expect(state).toMatchObject({
+      mode: "drawing",
+      lastPoint: { x: 50, y: 20 },
+    })
   })
 
   it("rejects an invalid pointer smoothing time constant", () => {

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -212,7 +212,7 @@ describe("gesture jitter and accidental activation resistance", () => {
       1,
     )
     expect(intentionTypes.filter((type) => type === "DRAW_MOVE")).toHaveLength(
-      6,
+      7,
     )
     expect(intentionTypes).not.toContain("DRAW_END")
     expect(state).toMatchObject({

--- a/src/core/gestures/gesture-resistance.test.ts
+++ b/src/core/gestures/gesture-resistance.test.ts
@@ -66,7 +66,7 @@ describe("gesture jitter and accidental activation resistance", () => {
     }
   })
 
-  it("rejects a pinch when tracking confidence is insufficient", () => {
+  it("does not use handedness certainty to reject a tracked pinch", () => {
     const gesture = classifyGesture(
       handFromGestureFixture(pinchGestureLandmarks, 0.2),
     ).kind
@@ -76,8 +76,8 @@ describe("gesture jitter and accidental activation resistance", () => {
       timestampMs: 16,
     })
 
-    expect(gesture).toBe("uncertain")
-    expect(intentions.map(({ type }) => type)).not.toContain("DRAW_START")
+    expect(gesture).toBe("pinch")
+    expect(intentions.map(({ type }) => type)).toContain("DRAW_START")
   })
 
   it("ends an active stroke when the hand disappears", () => {
@@ -86,12 +86,24 @@ describe("gesture jitter and accidental activation resistance", () => {
       point: { x: 10, y: 20 },
       timestampMs: 0,
     })
-    const lost = transitionGestureState(started.state, {
+    const firstGap = transitionGestureState(started.state, {
       gesture: classifyGesture(null).kind,
       point: null,
       timestampMs: 16,
     })
+    const secondGap = transitionGestureState(firstGap.state, {
+      gesture: "tracking-lost",
+      point: null,
+      timestampMs: 32,
+    })
+    const lost = transitionGestureState(secondGap.state, {
+      gesture: "tracking-lost",
+      point: null,
+      timestampMs: 48,
+    })
 
+    expect(firstGap.intentions).toEqual([])
+    expect(secondGap.intentions).toEqual([])
     expect(lost.intentions.map(({ type }) => type)).toEqual([
       "DRAW_END",
       "TRACKING_LOST",
@@ -122,9 +134,44 @@ describe("gesture jitter and accidental activation resistance", () => {
     })
 
     expect(transition).toEqual({
-      state: { mode: "idle", lastPoint: null },
+      state: {
+        mode: "idle",
+        lastPoint: null,
+        interruption: null,
+        interruptionFrames: 0,
+      },
       intentions: [],
     })
+  })
+
+  it("keeps one continuous stroke through a brief uncertain circle frame", () => {
+    const frames = [
+      { gesture: "pinch" as const, point: { x: 50, y: 20 } },
+      { gesture: "pinch" as const, point: { x: 80, y: 50 } },
+      { gesture: "uncertain" as const, point: null },
+      { gesture: "pinch" as const, point: { x: 50, y: 80 } },
+      { gesture: "pinch" as const, point: { x: 20, y: 50 } },
+      { gesture: "pinch" as const, point: { x: 50, y: 20 } },
+      { gesture: "open-hand" as const, point: { x: 50, y: 20 } },
+      { gesture: "open-hand" as const, point: { x: 50, y: 20 } },
+    ]
+    let state = initialGestureMachineState
+    const intentionTypes: string[] = []
+
+    frames.forEach((frame, index) => {
+      const transition = transitionGestureState(state, {
+        ...frame,
+        timestampMs: index * 16,
+      })
+      state = transition.state
+      intentionTypes.push(...transition.intentions.map(({ type }) => type))
+    })
+
+    expect(intentionTypes.filter((type) => type === "DRAW_START")).toHaveLength(
+      1,
+    )
+    expect(intentionTypes.filter((type) => type === "DRAW_END")).toHaveLength(1)
+    expect(state.mode).toBe("paused")
   })
 
   it("rejects an invalid pointer smoothing time constant", () => {

--- a/src/core/gestures/gesture-state-machine.test.ts
+++ b/src/core/gestures/gesture-state-machine.test.ts
@@ -4,6 +4,7 @@ import { DRAWING_INTENTION_VERSION } from "./drawing-intentions"
 import {
   initialGestureMachineState,
   transitionGestureState,
+  type GestureMachineState,
 } from "./gesture-state-machine"
 
 describe("transitionGestureState", () => {
@@ -60,6 +61,111 @@ describe("transitionGestureState", () => {
       "PAUSE",
     ])
     expect(transition.state.mode).toBe("paused")
+  })
+
+  it("buffers a provisional release and commits it when pinch recovers", () => {
+    const started = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      pinchPhase: "active",
+      point: { x: 10, y: 20 },
+      timestampMs: 0,
+    })
+    const firstPending = transitionGestureState(started.state, {
+      gesture: "pinch",
+      pinchPhase: "pending-release",
+      point: { x: 20, y: 30 },
+      timestampMs: 50,
+    })
+    const secondPending = transitionGestureState(firstPending.state, {
+      gesture: "pinch",
+      pinchPhase: "pending-release",
+      point: { x: 30, y: 40 },
+      timestampMs: 100,
+    })
+    const recovered = transitionGestureState(secondPending.state, {
+      gesture: "pinch",
+      pinchPhase: "active",
+      point: { x: 40, y: 50 },
+      timestampMs: 120,
+    })
+
+    expect(firstPending.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+    ])
+    expect(secondPending.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+    ])
+    expect(recovered.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_MOVE",
+      "DRAW_MOVE",
+      "DRAW_MOVE",
+    ])
+    expect(
+      recovered.intentions
+        .filter(({ type }) => type === "DRAW_MOVE")
+        .map((intention) => ("point" in intention ? intention.point : null)),
+    ).toEqual([
+      { x: 20, y: 30 },
+      { x: 30, y: 40 },
+      { x: 40, y: 50 },
+    ])
+    expect(recovered.state.pendingReleasePoints).toBeUndefined()
+  })
+
+  it("discards provisional points when release is confirmed", () => {
+    const drawing = {
+      mode: "drawing" as const,
+      lastPoint: { x: 10, y: 20 },
+      interruption: "release" as const,
+      interruptionFrames: 0,
+      pendingReleasePoints: [{ point: { x: 80, y: 90 }, timestampMs: 100 }],
+    }
+    const released = transitionGestureState(drawing, {
+      gesture: "open-hand",
+      pinchPhase: "released",
+      point: { x: 100, y: 110 },
+      timestampMs: 180,
+    })
+
+    expect(released.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_END",
+      "PAUSE",
+    ])
+    expect(released.intentions).toContainEqual({
+      version: DRAWING_INTENTION_VERSION,
+      type: "DRAW_END",
+      point: { x: 10, y: 20 },
+      timestampMs: 180,
+    })
+    expect(released.state.pendingReleasePoints).toBeUndefined()
+  })
+
+  it("still ends a pending release when tracking is lost", () => {
+    let state: GestureMachineState = {
+      mode: "drawing" as const,
+      lastPoint: { x: 10, y: 20 },
+      interruption: "release" as const,
+      interruptionFrames: 0,
+      pendingReleasePoints: [{ point: { x: 20, y: 30 }, timestampMs: 100 }],
+    }
+    const intentionTypes: string[] = []
+
+    for (const timestampMs of [116, 132, 148]) {
+      const transition = transitionGestureState(state, {
+        gesture: "tracking-lost",
+        pinchPhase: "pending-release",
+        point: null,
+        timestampMs,
+      })
+      state = transition.state
+      intentionTypes.push(...transition.intentions.map(({ type }) => type))
+    }
+
+    expect(intentionTypes).toEqual(["DRAW_END", "TRACKING_LOST"])
+    expect(state).toMatchObject({ mode: "lost", lastPoint: { x: 10, y: 20 } })
+    expect(state.pendingReleasePoints).toBeUndefined()
   })
 
   it("ends a stroke once and never extrapolates on tracking loss", () => {

--- a/src/core/gestures/gesture-state-machine.test.ts
+++ b/src/core/gestures/gesture-state-machine.test.ts
@@ -34,13 +34,26 @@ describe("transitionGestureState", () => {
     const state = {
       mode: "drawing" as const,
       lastPoint: { x: 12, y: 24 },
+      interruption: null,
+      interruptionFrames: 0,
     }
-    const transition = transitionGestureState(state, {
+    const pending = transitionGestureState(state, {
       gesture: "open-hand",
       point: { x: 15, y: 25 },
       timestampMs: 132,
     })
+    const transition = transitionGestureState(pending.state, {
+      gesture: "open-hand",
+      point: { x: 16, y: 26 },
+      timestampMs: 148,
+    })
 
+    expect(pending.intentions.map(({ type }) => type)).toEqual(["POINTER_MOVE"])
+    expect(pending.state).toMatchObject({
+      mode: "drawing",
+      interruption: "release",
+      interruptionFrames: 1,
+    })
     expect(transition.intentions.map(({ type }) => type)).toEqual([
       "POINTER_MOVE",
       "DRAW_END",
@@ -53,29 +66,43 @@ describe("transitionGestureState", () => {
     const drawingState = {
       mode: "drawing" as const,
       lastPoint: { x: 30, y: 40 },
+      interruption: null,
+      interruptionFrames: 0,
     }
-    const lost = transitionGestureState(drawingState, {
+    const firstGap = transitionGestureState(drawingState, {
       gesture: "tracking-lost",
       point: { x: 999, y: 999 },
       timestampMs: 200,
     })
-    const stillLost = transitionGestureState(lost.state, {
+    const secondGap = transitionGestureState(firstGap.state, {
       gesture: "tracking-lost",
       point: null,
       timestampMs: 216,
     })
+    const lost = transitionGestureState(secondGap.state, {
+      gesture: "tracking-lost",
+      point: null,
+      timestampMs: 232,
+    })
+    const stillLost = transitionGestureState(lost.state, {
+      gesture: "tracking-lost",
+      point: null,
+      timestampMs: 248,
+    })
 
+    expect(firstGap.intentions).toEqual([])
+    expect(secondGap.intentions).toEqual([])
     expect(lost.intentions).toEqual([
       {
         version: DRAWING_INTENTION_VERSION,
         type: "DRAW_END",
         point: { x: 30, y: 40 },
-        timestampMs: 200,
+        timestampMs: 232,
       },
       {
         version: DRAWING_INTENTION_VERSION,
         type: "TRACKING_LOST",
-        timestampMs: 200,
+        timestampMs: 232,
       },
     ])
     expect(stillLost.intentions).toEqual([])
@@ -83,11 +110,30 @@ describe("transitionGestureState", () => {
   })
 
   it("pauses safely when classification becomes uncertain", () => {
-    const transition = transitionGestureState(
-      { mode: "drawing", lastPoint: { x: 4, y: 8 } },
-      { gesture: "uncertain", point: { x: 20, y: 40 }, timestampMs: 50 },
-    )
+    const drawing = {
+      mode: "drawing" as const,
+      lastPoint: { x: 4, y: 8 },
+      interruption: null,
+      interruptionFrames: 0,
+    }
+    const firstGap = transitionGestureState(drawing, {
+      gesture: "uncertain",
+      point: { x: 20, y: 40 },
+      timestampMs: 50,
+    })
+    const secondGap = transitionGestureState(firstGap.state, {
+      gesture: "uncertain",
+      point: null,
+      timestampMs: 66,
+    })
+    const transition = transitionGestureState(secondGap.state, {
+      gesture: "uncertain",
+      point: null,
+      timestampMs: 82,
+    })
 
+    expect(firstGap.intentions).toEqual([])
+    expect(secondGap.intentions).toEqual([])
     expect(transition.intentions.map(({ type }) => type)).toEqual([
       "DRAW_END",
       "PAUSE",
@@ -95,6 +141,8 @@ describe("transitionGestureState", () => {
     expect(transition.state).toEqual({
       mode: "paused",
       lastPoint: { x: 4, y: 8 },
+      interruption: null,
+      interruptionFrames: 0,
     })
   })
 

--- a/src/core/gestures/gesture-state-machine.test.ts
+++ b/src/core/gestures/gesture-state-machine.test.ts
@@ -63,6 +63,63 @@ describe("transitionGestureState", () => {
     expect(transition.state.mode).toBe("paused")
   })
 
+  it("restores the first point collected while pinch entry is confirmed", () => {
+    const pending = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      pinchPhase: "pending-entry",
+      point: { x: 10, y: 20 },
+      timestampMs: 100,
+    })
+    const started = transitionGestureState(pending.state, {
+      gesture: "pinch",
+      pinchPhase: "active",
+      point: { x: 30, y: 40 },
+      timestampMs: 200,
+    })
+
+    expect(pending.intentions.map(({ type }) => type)).toEqual(["POINTER_MOVE"])
+    expect(started.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "DRAW_START",
+      "DRAW_MOVE",
+    ])
+    expect(started.intentions).toContainEqual({
+      version: DRAWING_INTENTION_VERSION,
+      type: "DRAW_START",
+      point: { x: 10, y: 20 },
+      timestampMs: 100,
+    })
+    expect(started.state).toMatchObject({
+      mode: "drawing",
+      lastPoint: { x: 30, y: 40 },
+    })
+    expect(started.state.pendingEntryPoints).toBeUndefined()
+  })
+
+  it("discards an entry candidate that is not confirmed", () => {
+    const pending = transitionGestureState(initialGestureMachineState, {
+      gesture: "pinch",
+      pinchPhase: "pending-entry",
+      point: { x: 10, y: 20 },
+      timestampMs: 100,
+    })
+    const released = transitionGestureState(pending.state, {
+      gesture: "open-hand",
+      pinchPhase: "released",
+      point: { x: 20, y: 30 },
+      timestampMs: 116,
+    })
+
+    expect(released.intentions.map(({ type }) => type)).toEqual([
+      "POINTER_MOVE",
+      "PAUSE",
+    ])
+    expect(released.intentions.map(({ type }) => type)).not.toContain(
+      "DRAW_START",
+    )
+    expect(released.state.pendingEntryPoints).toBeUndefined()
+  })
+
   it("buffers a provisional release and commits it when pinch recovers", () => {
     const started = transitionGestureState(initialGestureMachineState, {
       gesture: "pinch",

--- a/src/core/gestures/gesture-state-machine.ts
+++ b/src/core/gestures/gesture-state-machine.ts
@@ -7,10 +7,13 @@ import {
 } from "./drawing-intentions"
 
 export type GestureMachineMode = "idle" | "drawing" | "paused" | "lost"
+export type GestureInterruption = "release" | "tracking-gap" | null
 
 export type GestureMachineState = {
   mode: GestureMachineMode
   lastPoint: CanvasPoint | null
+  interruption: GestureInterruption
+  interruptionFrames: number
 }
 
 export type GestureFrame = {
@@ -27,7 +30,12 @@ export type GestureTransition = {
 export const initialGestureMachineState: GestureMachineState = {
   mode: "idle",
   lastPoint: null,
+  interruption: null,
+  interruptionFrames: 0,
 }
+
+const RELEASE_CONFIRMATION_FRAMES = 2
+const TRACKING_GRACE_FRAMES = 3
 
 function pointIntention(
   type: "POINTER_MOVE" | "DRAW_START" | "DRAW_MOVE" | "DRAW_END",
@@ -54,6 +62,28 @@ function stopDrawing(
   }
 }
 
+function clearInterruption(
+  state: Pick<GestureMachineState, "mode" | "lastPoint">,
+): GestureMachineState {
+  return {
+    ...state,
+    interruption: null,
+    interruptionFrames: 0,
+  }
+}
+
+function pendingInterruption(
+  state: GestureMachineState,
+  interruption: Exclude<GestureInterruption, null>,
+) {
+  const interruptionFrames =
+    state.interruption === interruption ? state.interruptionFrames + 1 : 1
+  return {
+    interruption,
+    interruptionFrames,
+  }
+}
+
 export function transitionGestureState(
   state: GestureMachineState,
   frame: GestureFrame,
@@ -74,8 +104,30 @@ export function transitionGestureState(
     const drawType = state.mode === "drawing" ? "DRAW_MOVE" : "DRAW_START"
     intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
     return {
-      state: { mode: "drawing", lastPoint: visiblePoint },
+      state: clearInterruption({ mode: "drawing", lastPoint: visiblePoint }),
       intentions,
+    }
+  }
+
+  if (state.mode === "drawing") {
+    const interruption =
+      frame.gesture === "open-hand"
+        ? "release"
+        : frame.gesture === "uncertain" || frame.gesture === "tracking-lost"
+          ? "tracking-gap"
+          : null
+    if (interruption) {
+      const pending = pendingInterruption(state, interruption)
+      const requiredFrames =
+        interruption === "release"
+          ? RELEASE_CONFIRMATION_FRAMES
+          : TRACKING_GRACE_FRAMES
+      if (pending.interruptionFrames < requiredFrames) {
+        return {
+          state: { ...state, ...pending },
+          intentions,
+        }
+      }
     }
   }
 
@@ -85,7 +137,7 @@ export function transitionGestureState(
       intentions.push(signalIntention("TRACKING_LOST", frame.timestampMs))
     }
     return {
-      state: { mode: "lost", lastPoint: state.lastPoint },
+      state: clearInterruption({ mode: "lost", lastPoint: state.lastPoint }),
       intentions,
     }
   }
@@ -100,19 +152,19 @@ export function transitionGestureState(
       intentions.push(signalIntention("PAUSE", frame.timestampMs))
     }
     return {
-      state: {
+      state: clearInterruption({
         mode: "paused",
         lastPoint: visiblePoint ?? state.lastPoint,
-      },
+      }),
       intentions,
     }
   }
 
   return {
-    state: {
+    state: clearInterruption({
       mode: "idle",
       lastPoint: visiblePoint ?? state.lastPoint,
-    },
+    }),
     intentions,
   }
 }

--- a/src/core/gestures/gesture-state-machine.ts
+++ b/src/core/gestures/gesture-state-machine.ts
@@ -16,13 +16,16 @@ export type GestureMachineState = {
   lastPoint: CanvasPoint | null
   interruption: GestureInterruption
   interruptionFrames: number
+  pendingEntryPoints?: PendingGesturePoint[]
   pendingReleasePoints?: PendingReleasePoint[]
 }
 
-type PendingReleasePoint = {
+type PendingGesturePoint = {
   point: CanvasPoint
   timestampMs: number
 }
+
+type PendingReleasePoint = PendingGesturePoint
 
 export type GestureFrame = {
   gesture: GestureKind
@@ -120,6 +123,23 @@ export function transitionGestureState(
     )
   }
 
+  if (frame.pinchPhase === "pending-entry" && visiblePoint) {
+    return {
+      state: {
+        ...state,
+        pendingEntryPoints: [
+          ...(state.pendingEntryPoints ?? []),
+          { point: visiblePoint, timestampMs: frame.timestampMs },
+        ],
+      },
+      intentions,
+    }
+  }
+
+  if (frame.pinchPhase === "pending-entry") {
+    return { state, intentions }
+  }
+
   if (
     frame.pinchPhase === "pending-release" &&
     frame.gesture === "pinch" &&
@@ -160,14 +180,29 @@ export function transitionGestureState(
 
   if (frame.gesture === "pinch" && visiblePoint) {
     const drawType = state.mode === "drawing" ? "DRAW_MOVE" : "DRAW_START"
-    if (drawType === "DRAW_MOVE") {
+    if (drawType === "DRAW_START" && state.pendingEntryPoints?.length) {
+      const first = state.pendingEntryPoints[0]!
+      intentions.push(
+        pointIntention("DRAW_START", first.point, first.timestampMs),
+      )
+      for (const buffered of state.pendingEntryPoints.slice(1)) {
+        intentions.push(
+          pointIntention("DRAW_MOVE", buffered.point, buffered.timestampMs),
+        )
+      }
+      intentions.push(
+        pointIntention("DRAW_MOVE", visiblePoint, frame.timestampMs),
+      )
+    } else if (drawType === "DRAW_MOVE") {
       for (const buffered of state.pendingReleasePoints ?? []) {
         intentions.push(
           pointIntention("DRAW_MOVE", buffered.point, buffered.timestampMs),
         )
       }
+      intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
+    } else {
+      intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
     }
-    intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
     return {
       state: clearInterruption({ mode: "drawing", lastPoint: visiblePoint }),
       intentions,

--- a/src/core/gestures/gesture-state-machine.ts
+++ b/src/core/gestures/gesture-state-machine.ts
@@ -20,6 +20,7 @@ export type GestureFrame = {
   gesture: GestureKind
   point: CanvasPoint | null
   timestampMs: number
+  continuous?: boolean
 }
 
 export type GestureTransition = {
@@ -89,6 +90,16 @@ export function transitionGestureState(
   frame: GestureFrame,
 ): GestureTransition {
   const intentions: DrawingIntention[] = []
+  if (frame.continuous === false) {
+    stopDrawing(state, intentions, frame.timestampMs)
+    if (state.mode !== "lost") {
+      intentions.push(signalIntention("TRACKING_LOST", frame.timestampMs))
+    }
+    return {
+      state: clearInterruption({ mode: "lost", lastPoint: state.lastPoint }),
+      intentions,
+    }
+  }
   const visiblePoint =
     frame.gesture === "tracking-lost" || frame.gesture === "uncertain"
       ? null

--- a/src/core/gestures/gesture-state-machine.ts
+++ b/src/core/gestures/gesture-state-machine.ts
@@ -1,6 +1,8 @@
 import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
 
 import type { GestureKind } from "./gesture-classifier"
+import type { PinchPhase } from "./pinch-detector"
+import { GESTURE_THRESHOLDS } from "./gesture-thresholds"
 import {
   DRAWING_INTENTION_VERSION,
   type DrawingIntention,
@@ -14,6 +16,12 @@ export type GestureMachineState = {
   lastPoint: CanvasPoint | null
   interruption: GestureInterruption
   interruptionFrames: number
+  pendingReleasePoints?: PendingReleasePoint[]
+}
+
+type PendingReleasePoint = {
+  point: CanvasPoint
+  timestampMs: number
 }
 
 export type GestureFrame = {
@@ -21,6 +29,7 @@ export type GestureFrame = {
   point: CanvasPoint | null
   timestampMs: number
   continuous?: boolean
+  pinchPhase?: PinchPhase
 }
 
 export type GestureTransition = {
@@ -111,8 +120,53 @@ export function transitionGestureState(
     )
   }
 
+  if (
+    frame.pinchPhase === "pending-release" &&
+    frame.gesture === "pinch" &&
+    state.mode === "drawing" &&
+    visiblePoint
+  ) {
+    const recentPoints = [
+      ...(state.pendingReleasePoints ?? []),
+      { point: visiblePoint, timestampMs: frame.timestampMs },
+    ].filter(
+      ({ timestampMs }) =>
+        frame.timestampMs - timestampMs <=
+        GESTURE_THRESHOLDS.drawingReleaseGraceMs,
+    )
+    return {
+      state: {
+        ...state,
+        interruption: "release",
+        interruptionFrames: 0,
+        pendingReleasePoints: recentPoints,
+      },
+      intentions,
+    }
+  }
+
+  if (frame.pinchPhase === "pending-release" && frame.gesture === "pinch") {
+    return { state, intentions }
+  }
+
+  if (frame.pinchPhase === "released" && state.mode === "drawing") {
+    stopDrawing(state, intentions, frame.timestampMs)
+    intentions.push(signalIntention("PAUSE", frame.timestampMs))
+    return {
+      state: clearInterruption({ mode: "paused", lastPoint: state.lastPoint }),
+      intentions,
+    }
+  }
+
   if (frame.gesture === "pinch" && visiblePoint) {
     const drawType = state.mode === "drawing" ? "DRAW_MOVE" : "DRAW_START"
+    if (drawType === "DRAW_MOVE") {
+      for (const buffered of state.pendingReleasePoints ?? []) {
+        intentions.push(
+          pointIntention("DRAW_MOVE", buffered.point, buffered.timestampMs),
+        )
+      }
+    }
     intentions.push(pointIntention(drawType, visiblePoint, frame.timestampMs))
     return {
       state: clearInterruption({ mode: "drawing", lastPoint: visiblePoint }),

--- a/src/core/gestures/gesture-thresholds.ts
+++ b/src/core/gestures/gesture-thresholds.ts
@@ -3,6 +3,10 @@ export const GESTURE_THRESHOLDS = {
   pinchEnterRatio: 0.18,
   /** Larger release boundary that prevents chatter around pinch entry. */
   pinchExitRatio: 0.24,
+  /** Drawing release boundary, widened to tolerate hand rotation mid-stroke. */
+  drawingPinchExitRatio: 0.34,
+  /** Time reserved for a pinched hand to recover before ending the stroke. */
+  drawingReleaseGraceMs: 150,
   /** Fingertip must exceed its PIP-to-wrist distance by this factor. */
   fingerExtensionRatio: 1.12,
   /** Index through little finger count needed for an open hand. */

--- a/src/core/gestures/gesture-thresholds.ts
+++ b/src/core/gestures/gesture-thresholds.ts
@@ -1,6 +1,4 @@
 export const GESTURE_THRESHOLDS = {
-  /** Minimum tracker confidence before a hand may produce a gesture. */
-  minimumHandConfidence: 0.65,
   /** Thumb-to-index distance, divided by palm size, required to enter pinch. */
   pinchEnterRatio: 0.18,
   /** Larger release boundary that prevents chatter around pinch entry. */

--- a/src/core/gestures/pinch-detector.test.ts
+++ b/src/core/gestures/pinch-detector.test.ts
@@ -14,7 +14,7 @@ describe("PinchDetector", () => {
     const rotatedPinch = handFromGestureFixture(withPinchRatio(0.3))
     const released = handFromGestureFixture(withPinchRatio(0.4))
 
-    expect(detector.update(pinched, true, 0).phase).toBe("released")
+    expect(detector.update(pinched, true, 0).phase).toBe("pending-entry")
     expect(detector.update(pinched, true, 16).phase).toBe("active")
     expect(detector.update(rotatedPinch, true, 32).phase).toBe("active")
     expect(detector.update(released, true, 48).phase).toBe("pending-release")
@@ -38,12 +38,21 @@ describe("PinchDetector", () => {
     const detector = new PinchDetector()
     const pinched = handFromGestureFixture(withPinchRatio(0.15))
 
-    expect(detector.update(pinched, true, 0).phase).toBe("released")
+    expect(detector.update(pinched, true, 0).phase).toBe("pending-entry")
     expect(detector.update(pinched, false, 16)).toEqual({
       phase: "released",
       ratio: null,
     })
-    expect(detector.update(pinched, true, 32).phase).toBe("released")
+    expect(detector.update(pinched, true, 32).phase).toBe("pending-entry")
+  })
+
+  it("cancels an unconfirmed entry without activating drawing", () => {
+    const detector = new PinchDetector()
+    const pinched = handFromGestureFixture(withPinchRatio(0.15))
+    const open = handFromGestureFixture(withPinchRatio(0.3))
+
+    expect(detector.update(pinched, true, 0).phase).toBe("pending-entry")
+    expect(detector.update(open, true, 16).phase).toBe("released")
   })
 
   it("prefers three-dimensional world landmarks for the pinch distance", () => {

--- a/src/core/gestures/pinch-detector.test.ts
+++ b/src/core/gestures/pinch-detector.test.ts
@@ -55,10 +55,19 @@ describe("PinchDetector", () => {
     expect(detector.update(open, true, 16).phase).toBe("released")
   })
 
-  it("prefers three-dimensional world landmarks for the pinch distance", () => {
-    const hand = handFromGestureFixture(withPinchRatio(0.15))
+  it("uses the visible projection when world depth conflicts with a pinch", () => {
+    const hand = handFromGestureFixture(withPinchRatio(0.1))
     hand.worldLandmarks = withPinchRatio(0.3)
 
-    expect(measurePinchRatio(hand)).toBeCloseTo(0.3)
+    expect(measurePinchRatio(hand)).toBeCloseTo(0.1)
+  })
+
+  it("activates from two projected pinch frames despite conflicting depth", () => {
+    const detector = new PinchDetector()
+    const hand = handFromGestureFixture(withPinchRatio(0.1))
+    hand.worldLandmarks = withPinchRatio(0.4)
+
+    expect(detector.update(hand, true, 0).phase).toBe("pending-entry")
+    expect(detector.update(hand, true, 16).phase).toBe("active")
   })
 })

--- a/src/core/gestures/pinch-detector.test.ts
+++ b/src/core/gestures/pinch-detector.test.ts
@@ -8,27 +8,42 @@ import {
 import { measurePinchRatio, PinchDetector } from "./pinch-detector"
 
 describe("PinchDetector", () => {
-  it("confirms pinch entry and release on two reliable frames", () => {
+  it("confirms entry, tolerates hand rotation and delays release", () => {
     const detector = new PinchDetector()
     const pinched = handFromGestureFixture(withPinchRatio(0.15))
-    const released = handFromGestureFixture(withPinchRatio(0.3))
+    const rotatedPinch = handFromGestureFixture(withPinchRatio(0.3))
+    const released = handFromGestureFixture(withPinchRatio(0.4))
 
-    expect(detector.update(pinched, true).active).toBe(false)
-    expect(detector.update(pinched, true).active).toBe(true)
-    expect(detector.update(released, true).active).toBe(true)
-    expect(detector.update(released, true).active).toBe(false)
+    expect(detector.update(pinched, true, 0).phase).toBe("released")
+    expect(detector.update(pinched, true, 16).phase).toBe("active")
+    expect(detector.update(rotatedPinch, true, 32).phase).toBe("active")
+    expect(detector.update(released, true, 48).phase).toBe("pending-release")
+    expect(detector.update(released, true, 180).phase).toBe("pending-release")
+    expect(detector.update(released, true, 208).phase).toBe("released")
+  })
+
+  it("recovers a brief false release without ending the pinch", () => {
+    const detector = new PinchDetector()
+    const pinched = handFromGestureFixture(withPinchRatio(0.15))
+    const released = handFromGestureFixture(withPinchRatio(0.4))
+
+    detector.update(pinched, true, 0)
+    detector.update(pinched, true, 16)
+
+    expect(detector.update(released, true, 100).phase).toBe("pending-release")
+    expect(detector.update(pinched, true, 200).phase).toBe("active")
   })
 
   it("does not change pinch state from unreliable frames", () => {
     const detector = new PinchDetector()
     const pinched = handFromGestureFixture(withPinchRatio(0.15))
 
-    expect(detector.update(pinched, true).active).toBe(false)
-    expect(detector.update(pinched, false)).toEqual({
-      active: false,
+    expect(detector.update(pinched, true, 0).phase).toBe("released")
+    expect(detector.update(pinched, false, 16)).toEqual({
+      phase: "released",
       ratio: null,
     })
-    expect(detector.update(pinched, true).active).toBe(false)
+    expect(detector.update(pinched, true, 32).phase).toBe("released")
   })
 
   it("prefers three-dimensional world landmarks for the pinch distance", () => {

--- a/src/core/gestures/pinch-detector.test.ts
+++ b/src/core/gestures/pinch-detector.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  handFromGestureFixture,
+  withPinchRatio,
+} from "@/test/fixtures/gesture-landmarks"
+
+import { measurePinchRatio, PinchDetector } from "./pinch-detector"
+
+describe("PinchDetector", () => {
+  it("confirms pinch entry and release on two reliable frames", () => {
+    const detector = new PinchDetector()
+    const pinched = handFromGestureFixture(withPinchRatio(0.15))
+    const released = handFromGestureFixture(withPinchRatio(0.3))
+
+    expect(detector.update(pinched, true).active).toBe(false)
+    expect(detector.update(pinched, true).active).toBe(true)
+    expect(detector.update(released, true).active).toBe(true)
+    expect(detector.update(released, true).active).toBe(false)
+  })
+
+  it("does not change pinch state from unreliable frames", () => {
+    const detector = new PinchDetector()
+    const pinched = handFromGestureFixture(withPinchRatio(0.15))
+
+    expect(detector.update(pinched, true).active).toBe(false)
+    expect(detector.update(pinched, false)).toEqual({
+      active: false,
+      ratio: null,
+    })
+    expect(detector.update(pinched, true).active).toBe(false)
+  })
+
+  it("prefers three-dimensional world landmarks for the pinch distance", () => {
+    const hand = handFromGestureFixture(withPinchRatio(0.15))
+    hand.worldLandmarks = withPinchRatio(0.3)
+
+    expect(measurePinchRatio(hand)).toBeCloseTo(0.3)
+  })
+})

--- a/src/core/gestures/pinch-detector.ts
+++ b/src/core/gestures/pinch-detector.ts
@@ -10,23 +10,22 @@ const INDEX_TIP = 8
 const MIDDLE_MCP = 9
 const CONFIRMATION_FRAMES = 2
 
-function distance(a: NormalizedLandmark, b: NormalizedLandmark) {
-  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z)
+function projectedDistance(a: NormalizedLandmark, b: NormalizedLandmark) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
 }
 
 export function measurePinchRatio(hand: TrackedHand | null) {
   if (!hand) return null
-  const landmarks =
-    hand.worldLandmarks.length >= 21 ? hand.worldLandmarks : hand.landmarks
+  const landmarks = hand.landmarks
   const wrist = landmarks[WRIST]
   const thumbTip = landmarks[THUMB_TIP]
   const indexTip = landmarks[INDEX_TIP]
   const middleMcp = landmarks[MIDDLE_MCP]
   if (!wrist || !thumbTip || !indexTip || !middleMcp) return null
 
-  const palmSize = distance(wrist, middleMcp)
+  const palmSize = projectedDistance(wrist, middleMcp)
   if (palmSize <= Number.EPSILON) return null
-  return distance(thumbTip, indexTip) / palmSize
+  return projectedDistance(thumbTip, indexTip) / palmSize
 }
 
 export type PinchSignal = {

--- a/src/core/gestures/pinch-detector.ts
+++ b/src/core/gestures/pinch-detector.ts
@@ -30,36 +30,65 @@ export function measurePinchRatio(hand: TrackedHand | null) {
 }
 
 export type PinchSignal = {
-  active: boolean
+  phase: PinchPhase
   ratio: number | null
 }
 
+export type PinchPhase = "released" | "active" | "pending-release"
+
 /** Keeps pinch activation independent from pointer position and tracking UI. */
 export class PinchDetector {
-  #active = false
+  #phase: PinchPhase = "released"
   #candidateFrames = 0
+  #releaseStartedAtMs: number | null = null
 
-  update(hand: TrackedHand | null, reliable: boolean): PinchSignal {
+  update(
+    hand: TrackedHand | null,
+    reliable: boolean,
+    timestampMs: number,
+  ): PinchSignal {
     const ratio = reliable ? measurePinchRatio(hand) : null
     if (ratio === null) {
       this.#candidateFrames = 0
-      return { active: this.#active, ratio }
+      return { phase: this.#phase, ratio }
     }
 
-    const shouldChange = this.#active
-      ? ratio >= GESTURE_THRESHOLDS.pinchExitRatio
-      : ratio <= GESTURE_THRESHOLDS.pinchEnterRatio
-    this.#candidateFrames = shouldChange ? this.#candidateFrames + 1 : 0
-    if (this.#candidateFrames >= CONFIRMATION_FRAMES) {
-      this.#active = !this.#active
-      this.#candidateFrames = 0
+    if (this.#phase === "released") {
+      const entering = ratio <= GESTURE_THRESHOLDS.pinchEnterRatio
+      this.#candidateFrames = entering ? this.#candidateFrames + 1 : 0
+      if (this.#candidateFrames >= CONFIRMATION_FRAMES) {
+        this.#phase = "active"
+        this.#candidateFrames = 0
+      }
+      return { phase: this.#phase, ratio }
     }
 
-    return { active: this.#active, ratio }
+    if (ratio < GESTURE_THRESHOLDS.drawingPinchExitRatio) {
+      this.#phase = "active"
+      this.#releaseStartedAtMs = null
+      return { phase: this.#phase, ratio }
+    }
+
+    if (this.#phase === "active") {
+      this.#phase = "pending-release"
+      this.#releaseStartedAtMs = timestampMs
+      return { phase: this.#phase, ratio }
+    }
+
+    const releaseElapsedMs = Math.max(
+      0,
+      timestampMs - (this.#releaseStartedAtMs ?? timestampMs),
+    )
+    if (releaseElapsedMs >= GESTURE_THRESHOLDS.drawingReleaseGraceMs) {
+      this.#phase = "released"
+      this.#releaseStartedAtMs = null
+    }
+    return { phase: this.#phase, ratio }
   }
 
   reset() {
-    this.#active = false
+    this.#phase = "released"
     this.#candidateFrames = 0
+    this.#releaseStartedAtMs = null
   }
 }

--- a/src/core/gestures/pinch-detector.ts
+++ b/src/core/gestures/pinch-detector.ts
@@ -1,0 +1,65 @@
+import { GESTURE_THRESHOLDS } from "@/core/gestures/gesture-thresholds"
+import type {
+  NormalizedLandmark,
+  TrackedHand,
+} from "@/infrastructure/mediapipe/hand-tracker-port"
+
+const WRIST = 0
+const THUMB_TIP = 4
+const INDEX_TIP = 8
+const MIDDLE_MCP = 9
+const CONFIRMATION_FRAMES = 2
+
+function distance(a: NormalizedLandmark, b: NormalizedLandmark) {
+  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z)
+}
+
+export function measurePinchRatio(hand: TrackedHand | null) {
+  if (!hand) return null
+  const landmarks =
+    hand.worldLandmarks.length >= 21 ? hand.worldLandmarks : hand.landmarks
+  const wrist = landmarks[WRIST]
+  const thumbTip = landmarks[THUMB_TIP]
+  const indexTip = landmarks[INDEX_TIP]
+  const middleMcp = landmarks[MIDDLE_MCP]
+  if (!wrist || !thumbTip || !indexTip || !middleMcp) return null
+
+  const palmSize = distance(wrist, middleMcp)
+  if (palmSize <= Number.EPSILON) return null
+  return distance(thumbTip, indexTip) / palmSize
+}
+
+export type PinchSignal = {
+  active: boolean
+  ratio: number | null
+}
+
+/** Keeps pinch activation independent from pointer position and tracking UI. */
+export class PinchDetector {
+  #active = false
+  #candidateFrames = 0
+
+  update(hand: TrackedHand | null, reliable: boolean): PinchSignal {
+    const ratio = reliable ? measurePinchRatio(hand) : null
+    if (ratio === null) {
+      this.#candidateFrames = 0
+      return { active: this.#active, ratio }
+    }
+
+    const shouldChange = this.#active
+      ? ratio >= GESTURE_THRESHOLDS.pinchExitRatio
+      : ratio <= GESTURE_THRESHOLDS.pinchEnterRatio
+    this.#candidateFrames = shouldChange ? this.#candidateFrames + 1 : 0
+    if (this.#candidateFrames >= CONFIRMATION_FRAMES) {
+      this.#active = !this.#active
+      this.#candidateFrames = 0
+    }
+
+    return { active: this.#active, ratio }
+  }
+
+  reset() {
+    this.#active = false
+    this.#candidateFrames = 0
+  }
+}

--- a/src/core/gestures/pinch-detector.ts
+++ b/src/core/gestures/pinch-detector.ts
@@ -34,7 +34,8 @@ export type PinchSignal = {
   ratio: number | null
 }
 
-export type PinchPhase = "released" | "active" | "pending-release"
+export type PinchPhase =
+  "released" | "pending-entry" | "active" | "pending-release"
 
 /** Keeps pinch activation independent from pointer position and tracking UI. */
 export class PinchDetector {
@@ -50,15 +51,20 @@ export class PinchDetector {
     const ratio = reliable ? measurePinchRatio(hand) : null
     if (ratio === null) {
       this.#candidateFrames = 0
+      if (this.#phase === "pending-entry") {
+        this.#phase = "released"
+      }
       return { phase: this.#phase, ratio }
     }
 
-    if (this.#phase === "released") {
+    if (this.#phase === "released" || this.#phase === "pending-entry") {
       const entering = ratio <= GESTURE_THRESHOLDS.pinchEnterRatio
       this.#candidateFrames = entering ? this.#candidateFrames + 1 : 0
       if (this.#candidateFrames >= CONFIRMATION_FRAMES) {
         this.#phase = "active"
         this.#candidateFrames = 0
+      } else {
+        this.#phase = entering ? "pending-entry" : "released"
       }
       return { phase: this.#phase, ratio }
     }

--- a/src/core/gestures/pointer-motion-filter.test.ts
+++ b/src/core/gestures/pointer-motion-filter.test.ts
@@ -37,14 +37,19 @@ describe("mapMirroredCameraPointToCanvas", () => {
 })
 
 describe("PointerMotionFilter", () => {
-  it("smooths pointer movement over elapsed time", () => {
-    const filter = new PointerMotionFilter({ timeConstantMs: 100 })
+  it("smooths ordinary pointer movement without adding fixed latency", () => {
+    const filter = new PointerMotionFilter()
 
-    expect(filter.update({ x: 0, y: 0 }, 0).point).toEqual({ x: 0, y: 0 })
-    const moved = filter.update({ x: 100, y: 50 }, 100).point
+    expect(filter.update({ x: 0.4, y: 0.4 }, 0).point).toEqual({
+      x: 0.4,
+      y: 0.4,
+    })
+    const moved = filter.update({ x: 0.5, y: 0.45 }, 100).point
 
-    expect(moved?.x).toBeCloseTo(63.21, 2)
-    expect(moved?.y).toBeCloseTo(31.61, 2)
+    expect(moved?.x).toBeGreaterThan(0.4)
+    expect(moved?.x).toBeLessThan(0.5)
+    expect(moved?.y).toBeGreaterThan(0.4)
+    expect(moved?.y).toBeLessThan(0.45)
   })
 
   it("locks the last reliable position without extrapolating on loss", () => {
@@ -55,21 +60,43 @@ describe("PointerMotionFilter", () => {
     expect(filter.update(null, 90)).toEqual({
       point: lastReliable.point,
       reliable: false,
+      discontinuity: false,
     })
     expect(filter.update(null, 10_000)).toEqual({
       point: lastReliable.point,
       reliable: false,
+      discontinuity: false,
     })
   })
 
-  it("restarts from the next reliable point after tracking loss", () => {
+  it("keeps a nearby reacquisition continuous after tracking loss", () => {
     const filter = new PointerMotionFilter()
-    filter.update({ x: 10, y: 10 }, 0)
+    filter.update({ x: 0.4, y: 0.4 }, 0)
     filter.update(null, 16)
 
-    expect(filter.update({ x: 90, y: 80 }, 32)).toEqual({
-      point: { x: 90, y: 80 },
+    const reacquired = filter.update({ x: 0.43, y: 0.42 }, 32)
+    expect(reacquired.reliable).toBe(true)
+    expect(reacquired.discontinuity).toBe(false)
+  })
+
+  it("rejects and confirms a distant reacquisition without bridging it", () => {
+    const filter = new PointerMotionFilter()
+    filter.update({ x: 0.5, y: 0.85 }, 0)
+    filter.update(null, 16)
+
+    expect(filter.update({ x: 0.5, y: 0.1 }, 32)).toEqual({
+      point: { x: 0.5, y: 0.85 },
+      reliable: false,
+      discontinuity: true,
+    })
+    expect(filter.update({ x: 0.51, y: 0.11 }, 48)).toEqual({
+      point: { x: 0.51, y: 0.11 },
       reliable: true,
+      discontinuity: true,
+    })
+    expect(filter.update({ x: 0.52, y: 0.12 }, 64)).toMatchObject({
+      reliable: true,
+      discontinuity: false,
     })
   })
 
@@ -78,6 +105,10 @@ describe("PointerMotionFilter", () => {
     filter.update({ x: 10, y: 10 }, 0)
     filter.reset()
 
-    expect(filter.update(null, 16)).toEqual({ point: null, reliable: false })
+    expect(filter.update(null, 16)).toEqual({
+      point: null,
+      reliable: false,
+      discontinuity: false,
+    })
   })
 })

--- a/src/core/gestures/pointer-motion-filter.test.ts
+++ b/src/core/gestures/pointer-motion-filter.test.ts
@@ -22,6 +22,18 @@ describe("mapMirroredCameraPointToCanvas", () => {
       ),
     ).toEqual({ x: 100, y: 50 })
   })
+
+  it("maps a comfortable inner camera region across the full canvas", () => {
+    const bounds = { left: 0, top: 0, width: 1000, height: 500 }
+    const region = { left: 0.1, right: 0.9, top: 0.2, bottom: 0.8 }
+
+    expect(
+      mapMirroredCameraPointToCanvas({ x: 0.1, y: 0.2 }, bounds, region),
+    ).toEqual({ x: 1000, y: 0 })
+    expect(
+      mapMirroredCameraPointToCanvas({ x: 0.9, y: 0.8 }, bounds, region),
+    ).toEqual({ x: 0, y: 500 })
+  })
 })
 
 describe("PointerMotionFilter", () => {

--- a/src/core/gestures/pointer-motion-filter.test.ts
+++ b/src/core/gestures/pointer-motion-filter.test.ts
@@ -23,7 +23,7 @@ describe("mapMirroredCameraPointToCanvas", () => {
     ).toEqual({ x: 100, y: 50 })
   })
 
-  it("maps a comfortable inner camera region across the full canvas", () => {
+  it("supports an explicit calibrated region when one is provided", () => {
     const bounds = { left: 0, top: 0, width: 1000, height: 500 }
     const region = { left: 0.1, right: 0.9, top: 0.2, bottom: 0.8 }
 

--- a/src/core/gestures/pointer-motion-filter.ts
+++ b/src/core/gestures/pointer-motion-filter.ts
@@ -3,24 +3,92 @@ import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
 export type FilteredPointer = {
   point: CanvasPoint | null
   reliable: boolean
+  discontinuity: boolean
 }
 
 export type PointerMotionFilterOptions = {
-  timeConstantMs?: number
+  minCutoffHz?: number
+  velocityCutoffHz?: number
+  velocityWeight?: number
+  jumpTolerance?: number
+  maxNormalizedSpeed?: number
+  jumpConfirmationRadius?: number
 }
 
-const DEFAULT_TIME_CONSTANT_MS = 70
+type AxisFilterState = {
+  raw: number
+  filtered: number
+  velocity: number
+}
 
+const DEFAULT_MIN_CUTOFF_HZ = 1
+const DEFAULT_VELOCITY_CUTOFF_HZ = 1
+const DEFAULT_VELOCITY_WEIGHT = 0.5
+const DEFAULT_JUMP_TOLERANCE = 0.08
+const DEFAULT_MAX_NORMALIZED_SPEED = 1.6
+const DEFAULT_JUMP_CONFIRMATION_RADIUS = 0.08
+const MAX_FILTER_INTERVAL_SECONDS = 0.1
+const MAX_JUMP_INTERVAL_SECONDS = 0.25
+
+function smoothingAlpha(elapsedSeconds: number, cutoffHz: number) {
+  const timeConstant = 1 / (2 * Math.PI * cutoffHz)
+  return 1 / (1 + timeConstant / elapsedSeconds)
+}
+
+function lowPass(previous: number, value: number, alpha: number) {
+  return previous + alpha * (value - previous)
+}
+
+function positiveOption(value: number, name: string) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Pointer filter ${name} must be greater than zero`)
+  }
+  return value
+}
+
+/**
+ * Speed-adaptive One Euro pointer filter with a discontinuity guard.
+ * Coordinates are expected to stay normalized in the camera's [0, 1] space.
+ */
 export class PointerMotionFilter {
-  readonly #timeConstantMs: number
+  readonly #minCutoffHz: number
+  readonly #velocityCutoffHz: number
+  readonly #velocityWeight: number
+  readonly #jumpTolerance: number
+  readonly #maxNormalizedSpeed: number
+  readonly #jumpConfirmationRadius: number
+  #x: AxisFilterState | null = null
+  #y: AxisFilterState | null = null
   #lastReliablePoint: CanvasPoint | null = null
+  #lastRawPoint: CanvasPoint | null = null
   #lastTimestampMs: number | null = null
+  #pendingJump: CanvasPoint | null = null
 
   constructor(options: PointerMotionFilterOptions = {}) {
-    this.#timeConstantMs = options.timeConstantMs ?? DEFAULT_TIME_CONSTANT_MS
-    if (this.#timeConstantMs <= 0) {
-      throw new Error("Pointer filter timeConstantMs must be greater than zero")
-    }
+    this.#minCutoffHz = positiveOption(
+      options.minCutoffHz ?? DEFAULT_MIN_CUTOFF_HZ,
+      "minCutoffHz",
+    )
+    this.#velocityCutoffHz = positiveOption(
+      options.velocityCutoffHz ?? DEFAULT_VELOCITY_CUTOFF_HZ,
+      "velocityCutoffHz",
+    )
+    this.#velocityWeight = positiveOption(
+      options.velocityWeight ?? DEFAULT_VELOCITY_WEIGHT,
+      "velocityWeight",
+    )
+    this.#jumpTolerance = positiveOption(
+      options.jumpTolerance ?? DEFAULT_JUMP_TOLERANCE,
+      "jumpTolerance",
+    )
+    this.#maxNormalizedSpeed = positiveOption(
+      options.maxNormalizedSpeed ?? DEFAULT_MAX_NORMALIZED_SPEED,
+      "maxNormalizedSpeed",
+    )
+    this.#jumpConfirmationRadius = positiveOption(
+      options.jumpConfirmationRadius ?? DEFAULT_JUMP_CONFIRMATION_RADIUS,
+      "jumpConfirmationRadius",
+    )
   }
 
   update(
@@ -29,32 +97,104 @@ export class PointerMotionFilter {
     reliable = point !== null,
   ): FilteredPointer {
     if (!point || !reliable) {
-      this.#lastTimestampMs = null
-      return { point: this.#lastReliablePoint, reliable: false }
+      return {
+        point: this.#lastReliablePoint,
+        reliable: false,
+        discontinuity: false,
+      }
     }
 
-    if (!this.#lastReliablePoint || this.#lastTimestampMs === null) {
-      this.#lastReliablePoint = { ...point }
-      this.#lastTimestampMs = timestampMs
-      return { point: this.#lastReliablePoint, reliable: true }
+    if (!this.#lastRawPoint || this.#lastTimestampMs === null) {
+      return this.#reanchor(point, timestampMs, false)
     }
 
-    const elapsedMs = Math.max(0, timestampMs - this.#lastTimestampMs)
-    const alpha = 1 - Math.exp(-elapsedMs / this.#timeConstantMs)
-    this.#lastReliablePoint = {
-      x:
-        this.#lastReliablePoint.x +
-        (point.x - this.#lastReliablePoint.x) * alpha,
-      y:
-        this.#lastReliablePoint.y +
-        (point.y - this.#lastReliablePoint.y) * alpha,
+    if (
+      this.#pendingJump &&
+      Math.hypot(
+        point.x - this.#pendingJump.x,
+        point.y - this.#pendingJump.y,
+      ) <= this.#jumpConfirmationRadius
+    ) {
+      return this.#reanchor(point, timestampMs, true)
     }
+
+    const elapsedSeconds = Math.max(
+      1 / 120,
+      (timestampMs - this.#lastTimestampMs) / 1000,
+    )
+    const displacement = Math.hypot(
+      point.x - this.#lastRawPoint.x,
+      point.y - this.#lastRawPoint.y,
+    )
+    const permittedDisplacement =
+      this.#jumpTolerance +
+      this.#maxNormalizedSpeed *
+        Math.min(elapsedSeconds, MAX_JUMP_INTERVAL_SECONDS)
+
+    if (displacement > permittedDisplacement) {
+      this.#pendingJump = { ...point }
+      return {
+        point: this.#lastReliablePoint,
+        reliable: false,
+        discontinuity: true,
+      }
+    }
+
+    this.#pendingJump = null
+    const filterInterval = Math.min(elapsedSeconds, MAX_FILTER_INTERVAL_SECONDS)
+    this.#x = this.#filterAxis(point.x, this.#x, filterInterval)
+    this.#y = this.#filterAxis(point.y, this.#y, filterInterval)
+    this.#lastRawPoint = { ...point }
     this.#lastTimestampMs = timestampMs
-    return { point: this.#lastReliablePoint, reliable: true }
+    this.#lastReliablePoint = {
+      x: this.#x.filtered,
+      y: this.#y.filtered,
+    }
+
+    return {
+      point: this.#lastReliablePoint,
+      reliable: true,
+      discontinuity: false,
+    }
   }
 
   reset() {
+    this.#x = null
+    this.#y = null
     this.#lastReliablePoint = null
+    this.#lastRawPoint = null
     this.#lastTimestampMs = null
+    this.#pendingJump = null
+  }
+
+  #filterAxis(value: number, state: AxisFilterState | null, elapsed: number) {
+    if (!state) return { raw: value, filtered: value, velocity: 0 }
+
+    const rawVelocity = (value - state.raw) / elapsed
+    const velocity = lowPass(
+      state.velocity,
+      rawVelocity,
+      smoothingAlpha(elapsed, this.#velocityCutoffHz),
+    )
+    const cutoff = this.#minCutoffHz + this.#velocityWeight * Math.abs(velocity)
+    return {
+      raw: value,
+      filtered: lowPass(state.filtered, value, smoothingAlpha(elapsed, cutoff)),
+      velocity,
+    }
+  }
+
+  #reanchor(
+    point: CanvasPoint,
+    timestampMs: number,
+    discontinuity: boolean,
+  ): FilteredPointer {
+    this.#x = { raw: point.x, filtered: point.x, velocity: 0 }
+    this.#y = { raw: point.y, filtered: point.y, velocity: 0 }
+    this.#lastRawPoint = { ...point }
+    this.#lastReliablePoint = { ...point }
+    this.#lastTimestampMs = timestampMs
+    this.#pendingJump = null
+    return { point: this.#lastReliablePoint, reliable: true, discontinuity }
   }
 }

--- a/src/features/camera/camera-preview.test.tsx
+++ b/src/features/camera/camera-preview.test.tsx
@@ -35,6 +35,17 @@ function createAdapter(overrides: Partial<CameraAdapter> = {}) {
 }
 
 describe("CameraPreview", () => {
+  it("keeps the floating preview layout while calibrating", () => {
+    const { adapter } = createAdapter()
+
+    render(<CameraPreview adapterFactory={() => adapter} calibrating />)
+
+    expect(screen.getByRole("region", { name: "Aperçu caméra" })).toHaveClass(
+      "camera-preview",
+      "camera-preview--calibrating",
+    )
+  })
+
   it("explains local processing before requesting permission", () => {
     const { adapter } = createAdapter()
 

--- a/src/features/camera/camera-preview.test.tsx
+++ b/src/features/camera/camera-preview.test.tsx
@@ -35,15 +35,17 @@ function createAdapter(overrides: Partial<CameraAdapter> = {}) {
 }
 
 describe("CameraPreview", () => {
-  it("keeps the floating preview layout while calibrating", () => {
+  it("keeps one stable circular preview while showing calibration guidance", () => {
     const { adapter } = createAdapter()
 
     render(<CameraPreview adapterFactory={() => adapter} calibrating />)
 
-    expect(screen.getByRole("region", { name: "Aperçu caméra" })).toHaveClass(
-      "camera-preview",
-      "camera-preview--calibrating",
-    )
+    const preview = screen.getByRole("region", { name: "Aperçu caméra" })
+    expect(preview).toHaveClass("camera-preview")
+    expect(preview).not.toHaveClass("camera-preview--calibrating")
+    expect(
+      preview.querySelector(".camera-preview__calibration-guide"),
+    ).toBeInTheDocument()
   })
 
   it("explains local processing before requesting permission", () => {

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -92,6 +92,7 @@ export function CameraPreview({
     canvasRef,
     gesture,
     metrics,
+    pinchPhase,
     state: trackingState,
   } = useHandTracking(
     state === "ready",
@@ -185,7 +186,12 @@ export function CameraPreview({
                 className="camera-preview__gesture"
                 aria-label="Geste détecté"
               >
-                Geste · {gestureLabels[gesture]}
+                Geste ·{" "}
+                {pinchPhase === "active"
+                  ? "Pincement actif"
+                  : pinchPhase === "pending-release"
+                    ? "Relâchement à confirmer"
+                    : gestureLabels[gesture]}
               </Badge>
             ) : null}
             {import.meta.env.DEV && metrics ? (

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -93,6 +93,7 @@ export function CameraPreview({
     gesture,
     metrics,
     pinchPhase,
+    pinchRatio,
     state: trackingState,
   } = useHandTracking(
     state === "ready",
@@ -201,6 +202,7 @@ export function CameraPreview({
                 {Math.round(metrics.inferenceMs)} ms · {metrics.droppedFrames}{" "}
                 frame{metrics.droppedFrames === 1 ? "" : "s"} ignorée
                 {metrics.droppedFrames === 1 ? "" : "s"}
+                {pinchRatio === null ? "" : ` · pince ${pinchRatio.toFixed(2)}`}
               </span>
             ) : null}
             {devices.length > 1 ? (

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -24,6 +24,7 @@ type CameraPreviewProps = {
   adapterFactory?: CameraAdapterFactory
   trackerFactory?: HandTrackerFactory
   onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void
+  calibrating?: boolean
 }
 
 const trackingContent = {
@@ -77,6 +78,7 @@ export function CameraPreview({
   adapterFactory,
   trackerFactory,
   onGestureFrame,
+  calibrating = false,
 }: CameraPreviewProps) {
   const {
     devices,
@@ -97,6 +99,7 @@ export function CameraPreview({
     videoRef,
     trackerFactory,
     onGestureFrame,
+    calibrating ? "contain" : "cover",
   )
   const trackingStatus = trackingContent[trackingState]
   const error =
@@ -108,11 +111,14 @@ export function CameraPreview({
       : null
 
   return (
-    <section aria-label="Aperçu caméra" className="camera-preview">
+    <section
+      aria-label="Aperçu caméra"
+      className={`camera-preview${calibrating ? "camera-preview--calibrating" : ""}`}
+    >
       <div className="camera-preview__viewport">
         <video
           ref={videoRef}
-          className="camera-preview__video"
+          className={`camera-preview__video${calibrating ? "camera-preview__video--contain" : ""}`}
           aria-label="Flux vidéo local"
           autoPlay
           muted
@@ -125,6 +131,12 @@ export function CameraPreview({
           aria-label="Repères de la main détectée"
           hidden={state !== "ready"}
         />
+        {calibrating ? (
+          <div
+            className="camera-preview__calibration-guide"
+            aria-hidden="true"
+          />
+        ) : null}
 
         {state === "requesting" ? (
           <LoaderCircle aria-hidden="true" className="camera-preview__loader" />

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -15,15 +15,14 @@ import {
 } from "@/features/camera/use-camera-lifecycle"
 import {
   useHandTracking,
+  type GestureFrameListener,
   type HandTrackerFactory,
 } from "@/features/camera/use-hand-tracking"
-import type { GestureKind } from "@/core/gestures/gesture-classifier"
-import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
 
 type CameraPreviewProps = {
   adapterFactory?: CameraAdapterFactory
   trackerFactory?: HandTrackerFactory
-  onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void
+  onGestureFrame?: GestureFrameListener
   calibrating?: boolean
 }
 

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -187,11 +187,13 @@ export function CameraPreview({
                 aria-label="Geste détecté"
               >
                 Geste ·{" "}
-                {pinchPhase === "active"
-                  ? "Pincement actif"
-                  : pinchPhase === "pending-release"
-                    ? "Relâchement à confirmer"
-                    : gestureLabels[gesture]}
+                {pinchPhase === "pending-entry"
+                  ? "Pincement à confirmer"
+                  : pinchPhase === "active"
+                    ? "Pincement actif"
+                    : pinchPhase === "pending-release"
+                      ? "Relâchement à confirmer"
+                      : gestureLabels[gesture]}
               </Badge>
             ) : null}
             {import.meta.env.DEV && metrics ? (

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/features/camera/use-hand-tracking"
 import type { GestureKind } from "@/core/gestures/gesture-classifier"
 import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
+import { cn } from "@/lib/utils"
 
 type CameraPreviewProps = {
   adapterFactory?: CameraAdapterFactory
@@ -113,7 +114,10 @@ export function CameraPreview({
   return (
     <section
       aria-label="Aperçu caméra"
-      className={`camera-preview${calibrating ? "camera-preview--calibrating" : ""}`}
+      className={cn(
+        "camera-preview",
+        calibrating && "camera-preview--calibrating",
+      )}
     >
       <div className="camera-preview__viewport">
         <video

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/features/camera/use-hand-tracking"
 import type { GestureKind } from "@/core/gestures/gesture-classifier"
 import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
-import { cn } from "@/lib/utils"
 
 type CameraPreviewProps = {
   adapterFactory?: CameraAdapterFactory
@@ -100,7 +99,6 @@ export function CameraPreview({
     videoRef,
     trackerFactory,
     onGestureFrame,
-    calibrating ? "contain" : "cover",
   )
   const trackingStatus = trackingContent[trackingState]
   const error =
@@ -112,17 +110,11 @@ export function CameraPreview({
       : null
 
   return (
-    <section
-      aria-label="Aperçu caméra"
-      className={cn(
-        "camera-preview",
-        calibrating && "camera-preview--calibrating",
-      )}
-    >
+    <section aria-label="Aperçu caméra" className="camera-preview">
       <div className="camera-preview__viewport">
         <video
           ref={videoRef}
-          className={`camera-preview__video${calibrating ? "camera-preview__video--contain" : ""}`}
+          className="camera-preview__video"
           aria-label="Flux vidéo local"
           autoPlay
           muted

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -32,6 +32,7 @@ export function useHandTracking(
   videoRef: RefObject<HTMLVideoElement | null>,
   trackerFactory: HandTrackerFactory = createTracker,
   onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void,
+  previewFit: "cover" | "contain" = "cover",
 ) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
@@ -57,7 +58,7 @@ export function useHandTracking(
 
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
-    const renderer = new LandmarkOverlayRenderer(canvas, video)
+    const renderer = new LandmarkOverlayRenderer(canvas, video, previewFit)
     let tracker: HandTrackerPort
     try {
       tracker = trackerFactory((nextMetrics) => {
@@ -123,7 +124,7 @@ export function useHandTracking(
       session.dispose()
       renderer.clear()
     }
-  }, [enabled, trackerFactory, videoRef])
+  }, [enabled, previewFit, trackerFactory, videoRef])
 
   return {
     canvasRef,

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -32,7 +32,6 @@ export function useHandTracking(
   videoRef: RefObject<HTMLVideoElement | null>,
   trackerFactory: HandTrackerFactory = createTracker,
   onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void,
-  previewFit: "cover" | "contain" = "cover",
 ) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
@@ -59,7 +58,7 @@ export function useHandTracking(
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
     let ambiguousFrames = 0
-    const renderer = new LandmarkOverlayRenderer(canvas, video, previewFit)
+    const renderer = new LandmarkOverlayRenderer(canvas, video)
     let tracker: HandTrackerPort
     try {
       tracker = trackerFactory((nextMetrics) => {
@@ -134,7 +133,7 @@ export function useHandTracking(
       session.dispose()
       renderer.clear()
     }
-  }, [enabled, previewFit, trackerFactory, videoRef])
+  }, [enabled, trackerFactory, videoRef])
 
   return {
     canvasRef,

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -4,6 +4,7 @@ import {
   classifyGesture,
   type GestureKind,
 } from "@/core/gestures/gesture-classifier"
+import { PinchDetector } from "@/core/gestures/pinch-detector"
 import type {
   HandTrackerMetrics,
   HandTrackerPort,
@@ -27,6 +28,7 @@ export type GestureFrameListener = (
   result: HandTrackingResult,
   gesture: GestureKind,
   quality: TrackingQuality,
+  pinchActive: boolean,
 ) => void
 
 function createTracker(onMetrics: (metrics: HandTrackerMetrics) => void) {
@@ -64,6 +66,7 @@ export function useHandTracking(
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
     let ambiguousFrames = 0
+    const pinchDetector = new PinchDetector()
     const renderer = new LandmarkOverlayRenderer(canvas, video)
     let tracker: HandTrackerPort
     try {
@@ -85,6 +88,10 @@ export function useHandTracking(
             result.hands[0] ?? null,
             previousGesture,
           )
+          const pinch = pinchDetector.update(
+            result.hands[0] ?? null,
+            quality === "reliable",
+          )
           if (
             classification.kind === "uncertain" ||
             classification.kind === "tracking-lost"
@@ -95,7 +102,12 @@ export function useHandTracking(
             ambiguousFrames = 0
             previousGesture = classification.kind
           }
-          onGestureFrameRef.current?.(result, classification.kind, quality)
+          onGestureFrameRef.current?.(
+            result,
+            classification.kind,
+            quality,
+            pinch.active,
+          )
           setGesture((current) =>
             current === classification.kind ? current : classification.kind,
           )

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -4,7 +4,7 @@ import {
   classifyGesture,
   type GestureKind,
 } from "@/core/gestures/gesture-classifier"
-import { PinchDetector } from "@/core/gestures/pinch-detector"
+import { PinchDetector, type PinchPhase } from "@/core/gestures/pinch-detector"
 import type {
   HandTrackerMetrics,
   HandTrackerPort,
@@ -28,7 +28,7 @@ export type GestureFrameListener = (
   result: HandTrackingResult,
   gesture: GestureKind,
   quality: TrackingQuality,
-  pinchActive: boolean,
+  pinchPhase: PinchPhase,
 ) => void
 
 function createTracker(onMetrics: (metrics: HandTrackerMetrics) => void) {
@@ -44,6 +44,7 @@ export function useHandTracking(
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
   const [gesture, setGesture] = useState<GestureKind>("tracking-lost")
+  const [pinchPhase, setPinchPhase] = useState<PinchPhase>("released")
   const [metrics, setMetrics] = useState<HandTrackerMetrics | null>(null)
   const onGestureFrameRef = useRef(onGestureFrame)
 
@@ -65,6 +66,7 @@ export function useHandTracking(
 
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
+    let previousPinchPhase: PinchPhase = "released"
     let ambiguousFrames = 0
     const pinchDetector = new PinchDetector()
     const renderer = new LandmarkOverlayRenderer(canvas, video)
@@ -91,7 +93,12 @@ export function useHandTracking(
           const pinch = pinchDetector.update(
             result.hands[0] ?? null,
             quality === "reliable",
+            result.timestampMs,
           )
+          if (pinch.phase !== previousPinchPhase) {
+            previousPinchPhase = pinch.phase
+            setPinchPhase(pinch.phase)
+          }
           if (
             classification.kind === "uncertain" ||
             classification.kind === "tracking-lost"
@@ -106,10 +113,16 @@ export function useHandTracking(
             result,
             classification.kind,
             quality,
-            pinch.active,
+            pinch.phase,
           )
+          const displayedGesture: GestureKind =
+            quality === "lost"
+              ? "tracking-lost"
+              : pinch.phase !== "released"
+                ? "pinch"
+                : classification.kind
           setGesture((current) =>
-            current === classification.kind ? current : classification.kind,
+            current === displayedGesture ? current : displayedGesture,
           )
           setState((current) => (current === quality ? current : quality))
         }
@@ -123,8 +136,10 @@ export function useHandTracking(
 
     queueMicrotask(() => {
       if (active) {
+        previousPinchPhase = "released"
         setState("initializing")
         setGesture("tracking-lost")
+        setPinchPhase("released")
         setMetrics(null)
       }
     })
@@ -158,6 +173,7 @@ export function useHandTracking(
     canvasRef,
     gesture: enabled ? gesture : "tracking-lost",
     metrics: enabled ? metrics : null,
+    pinchPhase: enabled ? pinchPhase : "released",
     state: enabled ? state : "idle",
   }
 }

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -23,6 +23,12 @@ export type HandTrackerFactory = (
   onMetrics: (metrics: HandTrackerMetrics) => void,
 ) => HandTrackerPort
 
+export type GestureFrameListener = (
+  result: HandTrackingResult,
+  gesture: GestureKind,
+  quality: TrackingQuality,
+) => void
+
 function createTracker(onMetrics: (metrics: HandTrackerMetrics) => void) {
   return new WorkerHandTracker(undefined, onMetrics)
 }
@@ -31,7 +37,7 @@ export function useHandTracking(
   enabled: boolean,
   videoRef: RefObject<HTMLVideoElement | null>,
   trackerFactory: HandTrackerFactory = createTracker,
-  onGestureFrame?: (result: HandTrackingResult, gesture: GestureKind) => void,
+  onGestureFrame?: GestureFrameListener,
 ) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [state, setState] = useState<HandTrackingState>("idle")
@@ -89,7 +95,7 @@ export function useHandTracking(
             ambiguousFrames = 0
             previousGesture = classification.kind
           }
-          onGestureFrameRef.current?.(result, classification.kind)
+          onGestureFrameRef.current?.(result, classification.kind, quality)
           setGesture((current) =>
             current === classification.kind ? current : classification.kind,
           )

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -45,6 +45,7 @@ export function useHandTracking(
   const [state, setState] = useState<HandTrackingState>("idle")
   const [gesture, setGesture] = useState<GestureKind>("tracking-lost")
   const [pinchPhase, setPinchPhase] = useState<PinchPhase>("released")
+  const [pinchRatio, setPinchRatio] = useState<number | null>(null)
   const [metrics, setMetrics] = useState<HandTrackerMetrics | null>(null)
   const onGestureFrameRef = useRef(onGestureFrame)
 
@@ -67,6 +68,7 @@ export function useHandTracking(
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
     let previousPinchPhase: PinchPhase = "released"
+    let lastPinchDiagnosticAtMs = Number.NEGATIVE_INFINITY
     let ambiguousFrames = 0
     const pinchDetector = new PinchDetector()
     const renderer = new LandmarkOverlayRenderer(canvas, video)
@@ -98,6 +100,13 @@ export function useHandTracking(
           if (pinch.phase !== previousPinchPhase) {
             previousPinchPhase = pinch.phase
             setPinchPhase(pinch.phase)
+          }
+          if (
+            import.meta.env.DEV &&
+            result.timestampMs - lastPinchDiagnosticAtMs >= 250
+          ) {
+            lastPinchDiagnosticAtMs = result.timestampMs
+            setPinchRatio(pinch.ratio)
           }
           if (
             classification.kind === "uncertain" ||
@@ -140,6 +149,7 @@ export function useHandTracking(
         setState("initializing")
         setGesture("tracking-lost")
         setPinchPhase("released")
+        setPinchRatio(null)
         setMetrics(null)
       }
     })
@@ -174,6 +184,7 @@ export function useHandTracking(
     gesture: enabled ? gesture : "tracking-lost",
     metrics: enabled ? metrics : null,
     pinchPhase: enabled ? pinchPhase : "released",
+    pinchRatio: enabled ? pinchRatio : null,
     state: enabled ? state : "idle",
   }
 }

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -58,6 +58,7 @@ export function useHandTracking(
 
     let active = true
     let previousGesture: GestureKind = "tracking-lost"
+    let ambiguousFrames = 0
     const renderer = new LandmarkOverlayRenderer(canvas, video, previewFit)
     let tracker: HandTrackerPort
     try {
@@ -79,7 +80,16 @@ export function useHandTracking(
             result.hands[0] ?? null,
             previousGesture,
           )
-          previousGesture = classification.kind
+          if (
+            classification.kind === "uncertain" ||
+            classification.kind === "tracking-lost"
+          ) {
+            ambiguousFrames += 1
+            if (ambiguousFrames >= 3) previousGesture = classification.kind
+          } else {
+            ambiguousFrames = 0
+            previousGesture = classification.kind
+          }
           onGestureFrameRef.current?.(result, classification.kind)
           setGesture((current) =>
             current === classification.kind ? current : classification.kind,

--- a/src/features/camera/use-hand-tracking.ts
+++ b/src/features/camera/use-hand-tracking.ts
@@ -130,6 +130,7 @@ export function useHandTracking(
     })
     void session
       .start({
+        delegate: "GPU",
         maxHands: 1,
         minDetectionConfidence: 0.5,
         minPresenceConfidence: 0.5,

--- a/src/features/onboarding/gesture-coach.test.tsx
+++ b/src/features/onboarding/gesture-coach.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { GestureCoach } from "./gesture-coach"
+
+describe("GestureCoach", () => {
+  it.each([
+    [0, "Placez votre main dans le cadre"],
+    [1, "Pincez pour commencer un trait"],
+    [2, "Ouvrez la main pour faire une pause"],
+  ] as const)(
+    "announces step %s without motion-dependent content",
+    (step, title) => {
+      render(<GestureCoach step={step} onBack={vi.fn()} onRestart={vi.fn()} />)
+
+      expect(screen.getByRole("heading", { name: title })).toBeInTheDocument()
+      expect(
+        screen.getByRole("progressbar", {
+          name: `Progression du tutoriel : étape ${step + 1} sur 3`,
+        }),
+      ).toBeInTheDocument()
+    },
+  )
+
+  it("offers keyboard-operable back and restart fallbacks", async () => {
+    const user = userEvent.setup()
+    const onBack = vi.fn()
+    const onRestart = vi.fn()
+    render(<GestureCoach step={1} onBack={onBack} onRestart={onRestart} />)
+
+    screen.getByRole("button", { name: "Retour" }).focus()
+    await user.keyboard("{Enter}")
+    screen.getByRole("button", { name: "Recommencer" }).focus()
+    await user.keyboard("{Enter}")
+
+    expect(onBack).toHaveBeenCalledOnce()
+    expect(onRestart).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/onboarding/gesture-coach.tsx
+++ b/src/features/onboarding/gesture-coach.tsx
@@ -6,28 +6,29 @@ import { Progress } from "@/components/ui/progress"
 
 const steps = [
   {
-    title: "Pincez pour commencer un trait",
-    description: "Rapprochez doucement le pouce et l’index.",
-    Icon: ScanLine,
-  },
-  {
-    title: "Déplacez la main pour dessiner",
-    description: "Gardez le pincement et guidez le curseur sur la toile.",
+    title: "Placez votre main dans le cadre",
+    description: "Déplacez-la dans la zone violette sans toucher les bords.",
     Icon: Hand,
   },
   {
+    title: "Pincez pour commencer un trait",
+    description: "Joignez franchement le pouce et l’index.",
+    Icon: ScanLine,
+  },
+  {
     title: "Ouvrez la main pour faire une pause",
-    description: "Le trait s’arrête dès que vos doigts se séparent.",
+    description: "Écartez les doigts pour terminer immédiatement le trait.",
     Icon: Pause,
   },
 ] as const
 
 type GestureCoachProps = {
-  step: number
-  onStepChange: (step: number) => void
+  step: 0 | 1 | 2
+  onBack: () => void
+  onRestart: () => void
 }
 
-export function GestureCoach({ step, onStepChange }: GestureCoachProps) {
+export function GestureCoach({ step, onBack, onRestart }: GestureCoachProps) {
   const current = steps[step] ?? steps[0]
   const progress = ((step + 1) / steps.length) * 100
 
@@ -53,13 +54,16 @@ export function GestureCoach({ step, onStepChange }: GestureCoachProps) {
           className="mt-3 h-1.5"
         />
       </div>
-      <Button
-        className="h-11"
-        variant="secondary"
-        onClick={() => onStepChange((step + 1) % steps.length)}
-      >
-        {step === steps.length - 1 ? "Recommencer" : "Étape suivante"}
-      </Button>
+      <div className="flex gap-2">
+        {step > 0 ? (
+          <Button className="h-11" variant="ghost" onClick={onBack}>
+            Retour
+          </Button>
+        ) : null}
+        <Button className="h-11" variant="secondary" onClick={onRestart}>
+          Recommencer
+        </Button>
+      </div>
     </section>
   )
 }

--- a/src/features/onboarding/gesture-coach.tsx
+++ b/src/features/onboarding/gesture-coach.tsx
@@ -40,7 +40,9 @@ export function GestureCoach({ step, onBack, onRestart }: GestureCoachProps) {
       <div className="min-w-0 flex-1">
         <div className="mb-2 flex items-center gap-2">
           <Badge variant="outline">Étape {step + 1} sur 3</Badge>
-          <span className="text-muted-foreground text-xs">Tutoriel simulé</span>
+          <span className="text-muted-foreground text-xs">
+            Validation en direct
+          </span>
         </div>
         <h2 id="gesture-title" className="text-base font-semibold">
           {current.title}

--- a/src/features/onboarding/onboarding-machine.test.ts
+++ b/src/features/onboarding/onboarding-machine.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  initialOnboardingState,
+  observeOnboardingGesture,
+  ONBOARDING_STABLE_FRAMES,
+  previousOnboardingStep,
+  type OnboardingState,
+} from "./onboarding-machine"
+
+function observeRepeatedly(
+  state: OnboardingState,
+  gesture: Parameters<typeof observeOnboardingGesture>[1],
+  count = ONBOARDING_STABLE_FRAMES,
+) {
+  for (let index = 0; index < count; index += 1) {
+    state = observeOnboardingGesture(state, gesture)
+  }
+  return state
+}
+
+describe("onboarding progression", () => {
+  it("validates stable placement, pinch, then open hand", () => {
+    const placed = observeRepeatedly(initialOnboardingState, "open-hand")
+    const pinched = observeRepeatedly(placed, "pinch")
+    const completed = observeRepeatedly(pinched, "open-hand")
+
+    expect(placed.step).toBe(1)
+    expect(pinched.step).toBe(2)
+    expect(completed.step).toBe(3)
+  })
+
+  it("resets stability when the expected gesture is interrupted", () => {
+    let state = observeRepeatedly(
+      { step: 1, stableFrames: 0 },
+      "pinch",
+      ONBOARDING_STABLE_FRAMES - 1,
+    )
+    state = observeOnboardingGesture(state, "open-hand")
+
+    expect(state).toEqual({ step: 1, stableFrames: 0 })
+  })
+
+  it("does not churn identity for an already invalid or completed state", () => {
+    expect(observeOnboardingGesture(initialOnboardingState, "uncertain")).toBe(
+      initialOnboardingState,
+    )
+    const complete = { step: 3, stableFrames: 0 } as const
+    expect(observeOnboardingGesture(complete, "pinch")).toBe(complete)
+  })
+
+  it("supports returning to the previous step", () => {
+    expect(previousOnboardingStep({ step: 2, stableFrames: 6 })).toEqual({
+      step: 1,
+      stableFrames: 0,
+    })
+    expect(previousOnboardingStep(initialOnboardingState)).toEqual(
+      initialOnboardingState,
+    )
+  })
+})

--- a/src/features/onboarding/onboarding-machine.ts
+++ b/src/features/onboarding/onboarding-machine.ts
@@ -1,0 +1,49 @@
+import type { GestureKind } from "@/core/gestures/gesture-classifier"
+
+export type OnboardingStep = 0 | 1 | 2 | 3
+
+export type OnboardingState = {
+  step: OnboardingStep
+  stableFrames: number
+}
+
+export const ONBOARDING_STABLE_FRAMES = 10
+
+export const initialOnboardingState: OnboardingState = {
+  step: 0,
+  stableFrames: 0,
+}
+
+function matchesStep(step: OnboardingStep, gesture: GestureKind) {
+  if (step === 0) return gesture !== "tracking-lost" && gesture !== "uncertain"
+  if (step === 1) return gesture === "pinch"
+  if (step === 2) return gesture === "open-hand"
+  return false
+}
+
+export function observeOnboardingGesture(
+  state: OnboardingState,
+  gesture: GestureKind,
+): OnboardingState {
+  if (state.step === 3) return state
+  if (!matchesStep(state.step, gesture)) {
+    return state.stableFrames === 0 ? state : { ...state, stableFrames: 0 }
+  }
+  const stableFrames = state.stableFrames + 1
+  if (stableFrames < ONBOARDING_STABLE_FRAMES) {
+    return { ...state, stableFrames }
+  }
+  return {
+    step: (state.step + 1) as OnboardingStep,
+    stableFrames: 0,
+  }
+}
+
+export function previousOnboardingStep(
+  state: OnboardingState,
+): OnboardingState {
+  return {
+    step: Math.max(0, state.step - 1) as OnboardingStep,
+    stableFrames: 0,
+  }
+}

--- a/src/features/onboarding/onboarding-persistence.test.ts
+++ b/src/features/onboarding/onboarding-persistence.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  loadOnboardingCompletion,
+  resetOnboardingCompletion,
+  saveOnboardingCompletion,
+} from "./onboarding-persistence"
+
+describe("onboarding completion persistence", () => {
+  it("stores only a versioned completion flag", () => {
+    const storage = new Map<string, string>()
+    const adapter = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    } as unknown as Storage
+
+    saveOnboardingCompletion(adapter)
+    expect(loadOnboardingCompletion(adapter)).toBe(true)
+    expect([...storage.values()][0]).toBe(
+      JSON.stringify({ version: 1, completed: true }),
+    )
+    resetOnboardingCompletion(adapter)
+    expect(loadOnboardingCompletion(adapter)).toBe(false)
+  })
+
+  it("rejects missing, malformed, or outdated values", () => {
+    const getItem = vi
+      .fn<Storage["getItem"]>()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce("not-json")
+      .mockReturnValueOnce(JSON.stringify({ version: 0, completed: true }))
+    const storage = { getItem } as unknown as Storage
+
+    expect(loadOnboardingCompletion(storage)).toBe(false)
+    expect(loadOnboardingCompletion(storage)).toBe(false)
+    expect(loadOnboardingCompletion(storage)).toBe(false)
+  })
+
+  it("does not fail when browser storage is unavailable", () => {
+    const failure = new Error("blocked")
+    const storage = {
+      getItem: () => {
+        throw failure
+      },
+      removeItem: () => {
+        throw failure
+      },
+      setItem: () => {
+        throw failure
+      },
+    } as unknown as Storage
+
+    expect(loadOnboardingCompletion(storage)).toBe(false)
+    expect(() => saveOnboardingCompletion(storage)).not.toThrow()
+    expect(() => resetOnboardingCompletion(storage)).not.toThrow()
+  })
+})

--- a/src/features/onboarding/onboarding-persistence.ts
+++ b/src/features/onboarding/onboarding-persistence.ts
@@ -1,0 +1,38 @@
+const STORAGE_KEY = "drawmotion:onboarding"
+const STORAGE_VERSION = 1
+
+type OnboardingPreference = {
+  version: typeof STORAGE_VERSION
+  completed: boolean
+}
+
+export function loadOnboardingCompletion(storage: Storage = localStorage) {
+  try {
+    const value = storage.getItem(STORAGE_KEY)
+    if (!value) return false
+    const parsed = JSON.parse(value) as Partial<OnboardingPreference>
+    return parsed.version === STORAGE_VERSION && parsed.completed === true
+  } catch {
+    return false
+  }
+}
+
+export function saveOnboardingCompletion(storage: Storage = localStorage) {
+  const preference: OnboardingPreference = {
+    version: STORAGE_VERSION,
+    completed: true,
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(preference))
+  } catch {
+    // Drawing remains available when private storage is unavailable.
+  }
+}
+
+export function resetOnboardingCompletion(storage: Storage = localStorage) {
+  try {
+    storage.removeItem(STORAGE_KEY)
+  } catch {
+    // Reset is best-effort and never blocks the camera experience.
+  }
+}

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -1,67 +1,97 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 
 import { CanvasDrawingController } from "@/core/drawing/canvas-drawing-controller"
+import type { StrokeAssistanceFeedback } from "@/core/drawing/canvas-drawing-controller"
+import type { StrokeAssistanceMode } from "@/core/drawing/stroke-assistance"
 import { TwoLayerCanvasRenderer } from "@/core/drawing/two-layer-canvas-renderer"
 
 import type { DrawingIntention } from "@/core/gestures/drawing-intentions"
 
 export type DrawingCanvasHandle = {
   handleIntentions(intentions: readonly DrawingIntention[]): void
+  revertAssistance(strokeId: string): boolean
 }
 
-export const DrawingCanvas = forwardRef<DrawingCanvasHandle>(
-  function DrawingCanvas(_props, ref) {
-    const rootRef = useRef<HTMLDivElement>(null)
-    const persistentRef = useRef<HTMLCanvasElement>(null)
-    const interactionRef = useRef<HTMLCanvasElement>(null)
-    const controllerRef = useRef<CanvasDrawingController | null>(null)
+type DrawingCanvasProps = {
+  assistanceMode: StrokeAssistanceMode
+  onAssistance: (feedback: StrokeAssistanceFeedback) => void
+}
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        handleIntentions(intentions) {
-          for (const intention of intentions)
-            controllerRef.current?.handle(intention)
-        },
-      }),
-      [],
+export const DrawingCanvas = forwardRef<
+  DrawingCanvasHandle,
+  DrawingCanvasProps
+>(function DrawingCanvas(
+  { assistanceMode, onAssistance }: DrawingCanvasProps,
+  ref,
+) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const persistentRef = useRef<HTMLCanvasElement>(null)
+  const interactionRef = useRef<HTMLCanvasElement>(null)
+  const controllerRef = useRef<CanvasDrawingController | null>(null)
+  const onAssistanceRef = useRef(onAssistance)
+  const assistanceModeRef = useRef(assistanceMode)
+
+  useEffect(() => {
+    onAssistanceRef.current = onAssistance
+  }, [onAssistance])
+
+  useEffect(() => {
+    assistanceModeRef.current = assistanceMode
+    controllerRef.current?.setAssistanceMode(assistanceMode)
+  }, [assistanceMode])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      handleIntentions(intentions) {
+        for (const intention of intentions)
+          controllerRef.current?.handle(intention)
+      },
+      revertAssistance(strokeId) {
+        return controllerRef.current?.revertAssistance(strokeId) ?? false
+      },
+    }),
+    [],
+  )
+
+  useEffect(() => {
+    const root = rootRef.current
+    const persistent = persistentRef.current
+    const interaction = interactionRef.current
+    if (!root || !persistent || !interaction || !globalThis.ResizeObserver) {
+      return
+    }
+
+    const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
+    const controller = new CanvasDrawingController(renderer)
+    controller.setAssistanceMode(assistanceModeRef.current)
+    controller.setAssistanceListener((feedback) =>
+      onAssistanceRef.current(feedback),
     )
-
-    useEffect(() => {
-      const root = rootRef.current
-      const persistent = persistentRef.current
-      const interaction = interactionRef.current
-      if (!root || !persistent || !interaction || !globalThis.ResizeObserver) {
-        return
-      }
-
-      const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
-      const controller = new CanvasDrawingController(renderer)
-      controllerRef.current = controller
-      const observer = new ResizeObserver(([entry]) => {
-        if (!entry) return
-        const bounds = root.getBoundingClientRect()
-        controller.setBounds({
-          left: bounds.left,
-          top: bounds.top,
-          width: bounds.width,
-          height: bounds.height,
-        })
+    controllerRef.current = controller
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      const bounds = root.getBoundingClientRect()
+      controller.setBounds({
+        left: bounds.left,
+        top: bounds.top,
+        width: bounds.width,
+        height: bounds.height,
       })
-      observer.observe(root)
+    })
+    observer.observe(root)
 
-      return () => {
-        observer.disconnect()
-        controllerRef.current = null
-        renderer.dispose()
-      }
-    }, [])
+    return () => {
+      observer.disconnect()
+      controllerRef.current = null
+      renderer.dispose()
+    }
+  }, [])
 
-    return (
-      <div ref={rootRef} className="drawing-canvas" aria-hidden="true">
-        <canvas ref={persistentRef} className="drawing-canvas__layer" />
-        <canvas ref={interactionRef} className="drawing-canvas__layer" />
-      </div>
-    )
-  },
-)
+  return (
+    <div ref={rootRef} className="drawing-canvas" aria-hidden="true">
+      <canvas ref={persistentRef} className="drawing-canvas__layer" />
+      <canvas ref={interactionRef} className="drawing-canvas__layer" />
+    </div>
+  )
+})

--- a/src/features/workspace/precision-mode-selector.tsx
+++ b/src/features/workspace/precision-mode-selector.tsx
@@ -24,7 +24,7 @@ const modes = [
   {
     value: "shapes",
     label: "Formes",
-    description: "Régularise les lignes, cercles et ellipses reconnus",
+    description: "Régularise les lignes, cercles, ellipses et rectangles",
     icon: Shapes,
   },
 ] as const

--- a/src/features/workspace/precision-mode-selector.tsx
+++ b/src/features/workspace/precision-mode-selector.tsx
@@ -1,0 +1,68 @@
+import { Activity, PenLine, Shapes } from "lucide-react"
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import type { StrokeAssistanceMode } from "@/core/drawing/stroke-assistance"
+
+type PrecisionModeSelectorProps = {
+  value: StrokeAssistanceMode
+  onValueChange: (value: StrokeAssistanceMode) => void
+}
+
+const modes = [
+  {
+    value: "free",
+    label: "Libre",
+    description: "Respecte chaque mouvement sans correction de forme",
+    icon: PenLine,
+  },
+  {
+    value: "stabilized",
+    label: "Stabilisé",
+    description: "Réduit les irrégularités sans transformer le dessin",
+    icon: Activity,
+  },
+  {
+    value: "shapes",
+    label: "Formes",
+    description: "Régularise les lignes, cercles et ellipses reconnus",
+    icon: Shapes,
+  },
+] as const
+
+export function PrecisionModeSelector({
+  value,
+  onValueChange,
+}: PrecisionModeSelectorProps) {
+  return (
+    <div className="precision-mode" aria-label="Assistance au dessin">
+      <span className="precision-mode__label">Précision</span>
+      <ToggleGroup
+        value={[value]}
+        onValueChange={(nextValue) => {
+          const nextMode = nextValue[0]
+          if (nextMode) onValueChange(nextMode as StrokeAssistanceMode)
+        }}
+        variant="default"
+        size="sm"
+        spacing={0}
+        aria-label="Mode de précision"
+      >
+        {modes.map((mode) => {
+          const Icon = mode.icon
+          return (
+            <ToggleGroupItem
+              key={mode.value}
+              value={mode.value}
+              aria-label={`${mode.label} — ${mode.description}`}
+              title={mode.description}
+              className="precision-mode__option"
+            >
+              <Icon aria-hidden="true" />
+              {mode.label}
+            </ToggleGroupItem>
+          )
+        })}
+      </ToggleGroup>
+    </div>
+  )
+}

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -52,33 +52,22 @@ describe("WorkspaceShell", () => {
     ).toBeInTheDocument()
   })
 
-  it("rend les trois étapes du tutoriel simulé accessibles", async () => {
-    const user = userEvent.setup()
+  it("présente la calibration réelle avant le dessin", () => {
     renderWorkspace()
 
-    const nextStep = screen.getByRole("button", { name: "Étape suivante" })
     expect(
       screen.getByRole("progressbar", {
         name: "Progression du tutoriel : étape 1 sur 3",
       }),
     ).toBeInTheDocument()
-
-    await user.click(nextStep)
     expect(
       screen.getByRole("heading", {
         level: 2,
-        name: "Déplacez la main pour dessiner",
+        name: "Placez votre main dans le cadre",
       }),
     ).toBeInTheDocument()
-
-    await user.click(nextStep)
     expect(
       screen.getByRole("button", { name: "Recommencer" }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole("progressbar", {
-        name: "Progression du tutoriel : étape 3 sur 3",
-      }),
     ).toBeInTheDocument()
   })
 

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 
 import { AppProviders } from "@/app/providers"
 import { WorkspaceShell } from "@/features/workspace/workspace-shell"
+import { saveOnboardingCompletion } from "@/features/onboarding/onboarding-persistence"
 
 function renderWorkspace() {
   return render(
@@ -12,6 +13,8 @@ function renderWorkspace() {
     </AppProviders>,
   )
 }
+
+beforeEach(() => localStorage.clear())
 
 describe("WorkspaceShell", () => {
   it("expose une structure et des états techniques compréhensibles", () => {
@@ -78,5 +81,24 @@ describe("WorkspaceShell", () => {
     await user.tab()
 
     expect(screen.getByRole("link", { name: "Aller à la toile" })).toHaveFocus()
+  })
+
+  it("laisse choisir une assistance précise après le tutoriel", async () => {
+    const user = userEvent.setup()
+    saveOnboardingCompletion()
+    renderWorkspace()
+
+    const stabilized = screen.getByRole("button", {
+      name: /Stabilisé — Réduit les irrégularités/,
+    })
+    const shapes = screen.getByRole("button", {
+      name: /Formes — Régularise les lignes/,
+    })
+    expect(stabilized).toHaveAttribute("aria-pressed", "true")
+
+    await user.click(shapes)
+
+    expect(shapes).toHaveAttribute("aria-pressed", "true")
+    expect(stabilized).toHaveAttribute("aria-pressed", "false")
   })
 })

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -95,10 +95,13 @@ describe("WorkspaceShell", () => {
       name: /Formes — Régularise les lignes/,
     })
     expect(stabilized).toHaveAttribute("aria-pressed", "true")
+    expect(stabilized).toHaveAttribute("data-pressed")
 
     await user.click(shapes)
 
     expect(shapes).toHaveAttribute("aria-pressed", "true")
+    expect(shapes).toHaveAttribute("data-pressed")
+    expect(stabilized).not.toHaveAttribute("data-pressed")
     expect(stabilized).toHaveAttribute("aria-pressed", "false")
   })
 })

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -29,6 +29,7 @@ import {
   type DrawingCanvasHandle,
 } from "@/features/workspace/drawing-canvas"
 import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
+import { Button } from "@/components/ui/button"
 
 import "./workspace.css"
 
@@ -41,6 +42,7 @@ const toolNames: Record<DrawingTool, string> = {
 export function WorkspaceShell() {
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(0)
+  const [showRecoveryGuidance, setShowRecoveryGuidance] = useState(false)
   const stageRef = useRef<HTMLElement>(null)
   const drawingRef = useRef<DrawingCanvasHandle>(null)
   const pointerFilterRef = useRef(new PointerMotionFilter())
@@ -48,10 +50,12 @@ export function WorkspaceShell() {
     initialGestureMachineState,
   )
   const onboardingStateRef = useRef<OnboardingState>(initialOnboardingState)
+  const hesitationFramesRef = useRef(0)
 
   const restartOnboarding = useCallback(() => {
     onboardingStateRef.current = initialOnboardingState
     setOnboardingStep(0)
+    setShowRecoveryGuidance(false)
   }, [])
 
   const goBackOnboarding = useCallback(() => {
@@ -74,6 +78,17 @@ export function WorkspaceShell() {
       if (onboarding.step !== onboardingStep) {
         setOnboardingStep(onboarding.step)
       }
+      if (onboarding.step === 3) {
+        if (gesture === "uncertain" || gesture === "tracking-lost") {
+          hesitationFramesRef.current += 1
+          if (hesitationFramesRef.current === 30) {
+            setShowRecoveryGuidance(true)
+          }
+        } else {
+          hesitationFramesRef.current = 0
+          if (showRecoveryGuidance) setShowRecoveryGuidance(false)
+        }
+      }
       const filtered = pointerFilterRef.current.update(
         gesturePointer,
         result.timestampMs,
@@ -95,7 +110,7 @@ export function WorkspaceShell() {
       gestureStateRef.current = transition.state
       drawingRef.current?.handleIntentions(transition.intentions)
     },
-    [onboardingStep],
+    [onboardingStep, showRecoveryGuidance],
   )
 
   return (
@@ -119,15 +134,24 @@ export function WorkspaceShell() {
             {toolNames[activeTool]} sélectionné — simulation
           </div>
           <CameraPreview
-            calibrating={onboardingStep < 3}
+            calibrating={onboardingStep < 3 || showRecoveryGuidance}
             onGestureFrame={handleGestureFrame}
           />
-          {onboardingStep < 3 ? (
+          {onboardingStep < 3 || showRecoveryGuidance ? (
             <GestureCoach
-              step={onboardingStep as 0 | 1 | 2}
+              step={showRecoveryGuidance ? 0 : (onboardingStep as 0 | 1 | 2)}
               onBack={goBackOnboarding}
               onRestart={restartOnboarding}
             />
+          ) : null}
+          {onboardingStep === 3 && !showRecoveryGuidance ? (
+            <Button
+              className="gesture-review-action h-10 active:scale-[0.96]"
+              variant="secondary"
+              onClick={restartOnboarding}
+            >
+              Revoir les gestes
+            </Button>
           ) : null}
         </section>
       </main>

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useRef, useState } from "react"
 
+import { Undo2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import type { StrokeAssistanceFeedback } from "@/core/drawing/canvas-drawing-controller"
+import type { AssistedPrimitive } from "@/core/drawing/drawing-model"
+import type { StrokeAssistanceMode } from "@/core/drawing/stroke-assistance"
 import type { GestureKind } from "@/core/gestures/gesture-classifier"
 import {
   initialGestureMachineState,
@@ -31,16 +37,22 @@ import {
   DrawingCanvas,
   type DrawingCanvasHandle,
 } from "@/features/workspace/drawing-canvas"
+import { PrecisionModeSelector } from "@/features/workspace/precision-mode-selector"
 import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
 import type { TrackingQuality } from "@/infrastructure/mediapipe/hand-tracking-session"
-import { Button } from "@/components/ui/button"
-
 import "./workspace.css"
 
 const toolNames: Record<DrawingTool, string> = {
   pointer: "Pointeur",
   pen: "Stylo",
   eraser: "Gomme",
+}
+
+const primitiveNames: Record<AssistedPrimitive, string> = {
+  line: "Ligne",
+  circle: "Cercle",
+  ellipse: "Ellipse",
+  rectangle: "Rectangle",
 }
 
 export function WorkspaceShell() {
@@ -50,6 +62,10 @@ export function WorkspaceShell() {
       : initialOnboardingState,
   )
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
+  const [assistanceMode, setAssistanceMode] =
+    useState<StrokeAssistanceMode>("stabilized")
+  const [lastAssistance, setLastAssistance] =
+    useState<StrokeAssistanceFeedback | null>(null)
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(
     initialState.step,
   )
@@ -120,10 +136,29 @@ export function WorkspaceShell() {
         pinchPhase,
       })
       gestureStateRef.current = transition.state
+      if (
+        transition.intentions.some(
+          (intention) => intention.type === "DRAW_START",
+        )
+      ) {
+        setLastAssistance(null)
+      }
       drawingRef.current?.handleIntentions(transition.intentions)
     },
     [onboardingStep],
   )
+
+  const changeAssistanceMode = useCallback((mode: StrokeAssistanceMode) => {
+    setAssistanceMode(mode)
+    setLastAssistance(null)
+  }, [])
+
+  const revertLastAssistance = useCallback(() => {
+    if (!lastAssistance) return
+    if (drawingRef.current?.revertAssistance(lastAssistance.strokeId)) {
+      setLastAssistance(null)
+    }
+  }, [lastAssistance])
 
   return (
     <div className="workspace-shell">
@@ -141,7 +176,11 @@ export function WorkspaceShell() {
           aria-label="Toile de dessin vide"
           className="drawing-stage"
         >
-          <DrawingCanvas ref={drawingRef} />
+          <DrawingCanvas
+            ref={drawingRef}
+            assistanceMode={assistanceMode}
+            onAssistance={setLastAssistance}
+          />
           <div className="sr-only" aria-live="polite">
             {toolNames[activeTool]} sélectionné — simulation
           </div>
@@ -157,13 +196,38 @@ export function WorkspaceShell() {
             />
           ) : null}
           {onboardingStep === 3 ? (
-            <Button
-              className="gesture-review-action h-10 active:scale-[0.96]"
-              variant="secondary"
-              onClick={restartOnboarding}
-            >
-              Revoir les gestes
-            </Button>
+            <>
+              <PrecisionModeSelector
+                value={assistanceMode}
+                onValueChange={changeAssistanceMode}
+              />
+              {lastAssistance ? (
+                <div
+                  className="shape-assistance-feedback"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span>
+                    {primitiveNames[lastAssistance.primitive]} régularisé
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={revertLastAssistance}
+                  >
+                    <Undo2 aria-hidden="true" />
+                    Garder mon tracé
+                  </Button>
+                </div>
+              ) : null}
+              <Button
+                className="gesture-review-action h-10 active:scale-[0.96]"
+                variant="secondary"
+                onClick={restartOnboarding}
+              >
+                Revoir les gestes
+              </Button>
+            </>
           ) : null}
         </section>
       </main>

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -22,6 +22,11 @@ import {
   type OnboardingState,
   type OnboardingStep,
 } from "@/features/onboarding/onboarding-machine"
+import {
+  loadOnboardingCompletion,
+  resetOnboardingCompletion,
+  saveOnboardingCompletion,
+} from "@/features/onboarding/onboarding-persistence"
 import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
 import { TopBar } from "@/features/toolbar/top-bar"
 import {
@@ -40,8 +45,15 @@ const toolNames: Record<DrawingTool, string> = {
 }
 
 export function WorkspaceShell() {
+  const [initialState] = useState<OnboardingState>(() =>
+    loadOnboardingCompletion()
+      ? { step: 3, stableFrames: 0 }
+      : initialOnboardingState,
+  )
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
-  const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(0)
+  const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(
+    initialState.step,
+  )
   const [showRecoveryGuidance, setShowRecoveryGuidance] = useState(false)
   const stageRef = useRef<HTMLElement>(null)
   const drawingRef = useRef<DrawingCanvasHandle>(null)
@@ -49,11 +61,12 @@ export function WorkspaceShell() {
   const gestureStateRef = useRef<GestureMachineState>(
     initialGestureMachineState,
   )
-  const onboardingStateRef = useRef<OnboardingState>(initialOnboardingState)
+  const onboardingStateRef = useRef<OnboardingState>(initialState)
   const hesitationFramesRef = useRef(0)
 
   const restartOnboarding = useCallback(() => {
     onboardingStateRef.current = initialOnboardingState
+    resetOnboardingCompletion()
     setOnboardingStep(0)
     setShowRecoveryGuidance(false)
   }, [])
@@ -77,6 +90,7 @@ export function WorkspaceShell() {
       onboardingStateRef.current = onboarding
       if (onboarding.step !== onboardingStep) {
         setOnboardingStep(onboarding.step)
+        if (onboarding.step === 3) saveOnboardingCompletion()
       }
       if (onboarding.step === 3) {
         if (gesture === "uncertain" || gesture === "tracking-lost") {

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -31,6 +31,7 @@ import {
   type DrawingCanvasHandle,
 } from "@/features/workspace/drawing-canvas"
 import type { HandTrackingResult } from "@/infrastructure/mediapipe/hand-tracker-port"
+import type { TrackingQuality } from "@/infrastructure/mediapipe/hand-tracking-session"
 import { Button } from "@/components/ui/button"
 
 import "./workspace.css"
@@ -72,7 +73,11 @@ export function WorkspaceShell() {
   }, [])
 
   const handleGestureFrame = useCallback(
-    (result: HandTrackingResult, gesture: GestureKind) => {
+    (
+      result: HandTrackingResult,
+      gesture: GestureKind,
+      quality: TrackingQuality,
+    ) => {
       const bounds = stageRef.current?.getBoundingClientRect()
       const hand = result.hands[0] ?? null
       const gesturePointer = selectGesturePointer(hand)
@@ -89,7 +94,7 @@ export function WorkspaceShell() {
       const filtered = pointerFilterRef.current.update(
         gesturePointer,
         result.timestampMs,
-        gesture !== "uncertain" && gesture !== "tracking-lost",
+        quality === "reliable",
       )
       const mapped = filtered.point
         ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
@@ -99,6 +104,7 @@ export function WorkspaceShell() {
         gesture,
         point: filtered.reliable ? mapped : null,
         timestampMs: result.timestampMs,
+        continuous: !filtered.discontinuity,
       })
       gestureStateRef.current = transition.state
       drawingRef.current?.handleIntentions(transition.intentions)

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -8,10 +8,20 @@ import {
 } from "@/core/gestures/gesture-state-machine"
 import { PointerMotionFilter } from "@/core/gestures/pointer-motion-filter"
 import { selectGesturePointer } from "@/core/gestures/gesture-pointer"
-import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
+import {
+  COMFORTABLE_CAMERA_REGION,
+  mapMirroredCameraPointToCanvas,
+} from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
+import {
+  initialOnboardingState,
+  observeOnboardingGesture,
+  previousOnboardingStep,
+  type OnboardingState,
+  type OnboardingStep,
+} from "@/features/onboarding/onboarding-machine"
 import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
 import { TopBar } from "@/features/toolbar/top-bar"
 import {
@@ -30,13 +40,25 @@ const toolNames: Record<DrawingTool, string> = {
 
 export function WorkspaceShell() {
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
-  const [coachStep, setCoachStep] = useState(0)
+  const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(0)
   const stageRef = useRef<HTMLElement>(null)
   const drawingRef = useRef<DrawingCanvasHandle>(null)
   const pointerFilterRef = useRef(new PointerMotionFilter())
   const gestureStateRef = useRef<GestureMachineState>(
     initialGestureMachineState,
   )
+  const onboardingStateRef = useRef<OnboardingState>(initialOnboardingState)
+
+  const restartOnboarding = useCallback(() => {
+    onboardingStateRef.current = initialOnboardingState
+    setOnboardingStep(0)
+  }, [])
+
+  const goBackOnboarding = useCallback(() => {
+    const previous = previousOnboardingStep(onboardingStateRef.current)
+    onboardingStateRef.current = previous
+    setOnboardingStep(previous.step)
+  }, [])
 
   const handleGestureFrame = useCallback(
     (result: HandTrackingResult, gesture: GestureKind) => {
@@ -44,14 +66,27 @@ export function WorkspaceShell() {
       const hand = result.hands[0] ?? null
       const gesturePointer = selectGesturePointer(hand, gesture)
       if (!bounds) return
+      const onboarding = observeOnboardingGesture(
+        onboardingStateRef.current,
+        gesture,
+      )
+      onboardingStateRef.current = onboarding
+      if (onboarding.step !== onboardingStep) {
+        setOnboardingStep(onboarding.step)
+      }
       const filtered = pointerFilterRef.current.update(
         gesturePointer,
         result.timestampMs,
         gesture !== "uncertain" && gesture !== "tracking-lost",
       )
       const mapped = filtered.point
-        ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
+        ? mapMirroredCameraPointToCanvas(
+            filtered.point,
+            bounds,
+            COMFORTABLE_CAMERA_REGION,
+          )
         : null
+      if (onboarding.step < 3) return
       const transition = transitionGestureState(gestureStateRef.current, {
         gesture,
         point: filtered.reliable ? mapped : null,
@@ -60,7 +95,7 @@ export function WorkspaceShell() {
       gestureStateRef.current = transition.state
       drawingRef.current?.handleIntentions(transition.intentions)
     },
-    [],
+    [onboardingStep],
   )
 
   return (
@@ -83,8 +118,17 @@ export function WorkspaceShell() {
           <div className="sr-only" aria-live="polite">
             {toolNames[activeTool]} sélectionné — simulation
           </div>
-          <CameraPreview onGestureFrame={handleGestureFrame} />
-          <GestureCoach step={coachStep} onStepChange={setCoachStep} />
+          <CameraPreview
+            calibrating={onboardingStep < 3}
+            onGestureFrame={handleGestureFrame}
+          />
+          {onboardingStep < 3 ? (
+            <GestureCoach
+              step={onboardingStep as 0 | 1 | 2}
+              onBack={goBackOnboarding}
+              onRestart={restartOnboarding}
+            />
+          ) : null}
         </section>
       </main>
     </div>

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -77,6 +77,7 @@ export function WorkspaceShell() {
       result: HandTrackingResult,
       gesture: GestureKind,
       quality: TrackingQuality,
+      pinchActive: boolean,
     ) => {
       const bounds = stageRef.current?.getBoundingClientRect()
       const hand = result.hands[0] ?? null
@@ -100,8 +101,17 @@ export function WorkspaceShell() {
         ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
         : null
       if (onboarding.step < 3) return
+      const drawingGesture: GestureKind = pinchActive
+        ? "pinch"
+        : quality === "lost"
+          ? "tracking-lost"
+          : quality === "uncertain"
+            ? "uncertain"
+            : gesture === "fist"
+              ? "fist"
+              : "open-hand"
       const transition = transitionGestureState(gestureStateRef.current, {
-        gesture,
+        gesture: drawingGesture,
         point: filtered.reliable ? mapped : null,
         timestampMs: result.timestampMs,
         continuous: !filtered.discontinuity,

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -54,7 +54,6 @@ export function WorkspaceShell() {
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(
     initialState.step,
   )
-  const [showRecoveryGuidance, setShowRecoveryGuidance] = useState(false)
   const stageRef = useRef<HTMLElement>(null)
   const drawingRef = useRef<DrawingCanvasHandle>(null)
   const pointerFilterRef = useRef(new PointerMotionFilter())
@@ -62,13 +61,11 @@ export function WorkspaceShell() {
     initialGestureMachineState,
   )
   const onboardingStateRef = useRef<OnboardingState>(initialState)
-  const hesitationFramesRef = useRef(0)
 
   const restartOnboarding = useCallback(() => {
     onboardingStateRef.current = initialOnboardingState
     resetOnboardingCompletion()
     setOnboardingStep(0)
-    setShowRecoveryGuidance(false)
   }, [])
 
   const goBackOnboarding = useCallback(() => {
@@ -92,17 +89,6 @@ export function WorkspaceShell() {
         setOnboardingStep(onboarding.step)
         if (onboarding.step === 3) saveOnboardingCompletion()
       }
-      if (onboarding.step === 3) {
-        if (gesture === "uncertain" || gesture === "tracking-lost") {
-          hesitationFramesRef.current += 1
-          if (hesitationFramesRef.current === 30) {
-            setShowRecoveryGuidance(true)
-          }
-        } else {
-          hesitationFramesRef.current = 0
-          if (showRecoveryGuidance) setShowRecoveryGuidance(false)
-        }
-      }
       const filtered = pointerFilterRef.current.update(
         gesturePointer,
         result.timestampMs,
@@ -124,7 +110,7 @@ export function WorkspaceShell() {
       gestureStateRef.current = transition.state
       drawingRef.current?.handleIntentions(transition.intentions)
     },
-    [onboardingStep, showRecoveryGuidance],
+    [onboardingStep],
   )
 
   return (
@@ -148,17 +134,17 @@ export function WorkspaceShell() {
             {toolNames[activeTool]} sélectionné — simulation
           </div>
           <CameraPreview
-            calibrating={onboardingStep < 3 || showRecoveryGuidance}
+            calibrating={onboardingStep < 3}
             onGestureFrame={handleGestureFrame}
           />
-          {onboardingStep < 3 || showRecoveryGuidance ? (
+          {onboardingStep < 3 ? (
             <GestureCoach
-              step={showRecoveryGuidance ? 0 : (onboardingStep as 0 | 1 | 2)}
+              step={onboardingStep as 0 | 1 | 2}
               onBack={goBackOnboarding}
               onRestart={restartOnboarding}
             />
           ) : null}
-          {onboardingStep === 3 && !showRecoveryGuidance ? (
+          {onboardingStep === 3 ? (
             <Button
               className="gesture-review-action h-10 active:scale-[0.96]"
               variant="secondary"

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -8,10 +8,7 @@ import {
 } from "@/core/gestures/gesture-state-machine"
 import { PointerMotionFilter } from "@/core/gestures/pointer-motion-filter"
 import { selectGesturePointer } from "@/core/gestures/gesture-pointer"
-import {
-  COMFORTABLE_CAMERA_REGION,
-  mapMirroredCameraPointToCanvas,
-} from "@/core/geometry/coordinate-mapping"
+import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
@@ -78,7 +75,7 @@ export function WorkspaceShell() {
     (result: HandTrackingResult, gesture: GestureKind) => {
       const bounds = stageRef.current?.getBoundingClientRect()
       const hand = result.hands[0] ?? null
-      const gesturePointer = selectGesturePointer(hand, gesture)
+      const gesturePointer = selectGesturePointer(hand)
       if (!bounds) return
       const onboarding = observeOnboardingGesture(
         onboardingStateRef.current,
@@ -95,11 +92,7 @@ export function WorkspaceShell() {
         gesture !== "uncertain" && gesture !== "tracking-lost",
       )
       const mapped = filtered.point
-        ? mapMirroredCameraPointToCanvas(
-            filtered.point,
-            bounds,
-            COMFORTABLE_CAMERA_REGION,
-          )
+        ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
         : null
       if (onboarding.step < 3) return
       const transition = transitionGestureState(gestureStateRef.current, {

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/core/gestures/gesture-state-machine"
 import { PointerMotionFilter } from "@/core/gestures/pointer-motion-filter"
 import { selectGesturePointer } from "@/core/gestures/gesture-pointer"
+import type { PinchPhase } from "@/core/gestures/pinch-detector"
 import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
@@ -77,7 +78,7 @@ export function WorkspaceShell() {
       result: HandTrackingResult,
       gesture: GestureKind,
       quality: TrackingQuality,
-      pinchActive: boolean,
+      pinchPhase: PinchPhase,
     ) => {
       const bounds = stageRef.current?.getBoundingClientRect()
       const hand = result.hands[0] ?? null
@@ -101,20 +102,22 @@ export function WorkspaceShell() {
         ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
         : null
       if (onboarding.step < 3) return
-      const drawingGesture: GestureKind = pinchActive
-        ? "pinch"
-        : quality === "lost"
+      const drawingGesture: GestureKind =
+        quality === "lost"
           ? "tracking-lost"
           : quality === "uncertain"
             ? "uncertain"
-            : gesture === "fist"
-              ? "fist"
-              : "open-hand"
+            : pinchPhase !== "released"
+              ? "pinch"
+              : gesture === "fist"
+                ? "fist"
+                : "open-hand"
       const transition = transitionGestureState(gestureStateRef.current, {
         gesture: drawingGesture,
         point: filtered.reliable ? mapped : null,
         timestampMs: result.timestampMs,
         continuous: !filtered.discontinuity,
+        pinchPhase,
       })
       gestureStateRef.current = transition.state
       drawingRef.current?.handleIntentions(transition.intentions)

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -266,6 +266,17 @@
   height: 1.5rem;
 }
 
+.gesture-review-action {
+  position: absolute;
+  right: var(--space-xl);
+  bottom: var(--space-xl);
+  z-index: var(--z-floating-controls);
+  box-shadow: 0 0.25rem 0.75rem oklch(0.06 0.01 286 / 18%);
+  transition-property: transform;
+  transition-duration: var(--duration-fast);
+  transition-timing-function: var(--ease-out-quart);
+}
+
 .skip-link {
   position: fixed;
   top: var(--space-sm);

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -90,6 +90,28 @@
   transform: scaleX(-1);
 }
 
+.camera-preview--calibrating {
+  width: 24rem;
+}
+
+.camera-preview--calibrating .camera-preview__viewport {
+  width: 22rem;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-xl);
+}
+
+.camera-preview__video--contain {
+  object-fit: contain;
+}
+
+.camera-preview__calibration-guide {
+  position: absolute;
+  inset: 10% 12%;
+  pointer-events: none;
+  border: 2px dashed var(--primary);
+  border-radius: var(--radius-md);
+}
+
 .camera-preview__landmarks {
   position: absolute;
   inset: 0;

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -90,26 +90,12 @@
   transform: scaleX(-1);
 }
 
-.camera-preview--calibrating {
-  width: 24rem;
-}
-
-.camera-preview--calibrating .camera-preview__viewport {
-  width: 22rem;
-  aspect-ratio: 16 / 9;
-  border-radius: var(--radius-xl);
-}
-
-.camera-preview__video--contain {
-  object-fit: contain;
-}
-
 .camera-preview__calibration-guide {
   position: absolute;
-  inset: 10% 12%;
+  inset: 12%;
   pointer-events: none;
   border: 2px dashed var(--primary);
-  border-radius: var(--radius-md);
+  border-radius: 50%;
 }
 
 .camera-preview__landmarks {

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -263,6 +263,53 @@
   transition-timing-function: var(--ease-out-quart);
 }
 
+.precision-mode {
+  position: absolute;
+  top: var(--space-xl);
+  left: 50%;
+  z-index: var(--z-floating-controls);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs);
+  color: var(--foreground);
+  background: var(--shell-raised);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 0.25rem 0.5rem oklch(0.06 0.01 286 / 20%);
+  transform: translateX(-50%);
+}
+
+.precision-mode__label {
+  padding-inline: var(--space-sm) var(--space-xs);
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.precision-mode__option[data-state="on"] {
+  color: var(--primary-foreground);
+  background: var(--primary);
+}
+
+.shape-assistance-feedback {
+  position: absolute;
+  bottom: var(--space-xl);
+  left: 50%;
+  z-index: var(--z-floating-controls);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 2.5rem;
+  padding: var(--space-xs) var(--space-xs) var(--space-xs) var(--space-md);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: var(--shell-raised);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 0.25rem 0.5rem oklch(0.06 0.01 286 / 20%);
+  transform: translateX(-50%);
+}
+
 .skip-link {
   position: fixed;
   top: var(--space-sm);

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -286,7 +286,7 @@
   font-weight: 500;
 }
 
-.precision-mode__option[data-state="on"] {
+.precision-mode__option[data-pressed] {
   color: var(--primary-foreground);
   background: var(--primary);
 }

--- a/src/infrastructure/mediapipe/hand-tracker-port.ts
+++ b/src/infrastructure/mediapipe/hand-tracker-port.ts
@@ -7,7 +7,7 @@ export type NormalizedLandmark = {
 
 export type TrackedHand = {
   handedness: "Left" | "Right" | "Unknown"
-  confidence: number
+  handednessConfidence: number
   landmarks: NormalizedLandmark[]
   worldLandmarks: NormalizedLandmark[]
 }

--- a/src/infrastructure/mediapipe/hand-tracker-port.ts
+++ b/src/infrastructure/mediapipe/hand-tracker-port.ts
@@ -25,6 +25,7 @@ export type HandTrackerMetrics = {
 }
 
 export type HandTrackerOptions = {
+  delegate?: "CPU" | "GPU"
   maxHands: number
   minDetectionConfidence: number
   minPresenceConfidence: number

--- a/src/infrastructure/mediapipe/hand-tracking-session.test.ts
+++ b/src/infrastructure/mediapipe/hand-tracking-session.test.ts
@@ -27,7 +27,15 @@ describe("HandTrackingSession", () => {
     expect(
       classifyTrackingQuality({
         ...deterministicTrackingResult,
-        hands: [{ ...deterministicTrackingResult.hands[0]!, confidence: 0.6 }],
+        hands: [
+          {
+            ...deterministicTrackingResult.hands[0]!,
+            landmarks: deterministicTrackingResult.hands[0]!.landmarks.slice(
+              0,
+              20,
+            ),
+          },
+        ],
       }),
     ).toBe("uncertain")
     expect(

--- a/src/infrastructure/mediapipe/hand-tracking-session.test.ts
+++ b/src/infrastructure/mediapipe/hand-tracking-session.test.ts
@@ -8,6 +8,7 @@ import {
   classifyTrackingQuality,
   HandTrackingSession,
 } from "@/infrastructure/mediapipe/hand-tracking-session"
+import { DroppedFrameError } from "@/infrastructure/mediapipe/worker-hand-tracker"
 import { deterministicTrackingResult } from "@/test/fixtures/hand-landmarks"
 
 const options: HandTrackerOptions = {
@@ -113,6 +114,63 @@ describe("HandTrackingSession", () => {
       "reliable",
     )
     expect(requestVideoFrameCallback).toHaveBeenCalledTimes(2)
+    session.dispose()
+    vi.unstubAllGlobals()
+  })
+
+  it("captures the latest video frame without waiting for inference", async () => {
+    const videoCallbacks: VideoFrameRequestCallback[] = []
+    const requestVideoFrameCallback = vi.fn(
+      (callback: VideoFrameRequestCallback) => {
+        videoCallbacks.push(callback)
+        return videoCallbacks.length
+      },
+    )
+    const video = {
+      cancelVideoFrameCallback: vi.fn(),
+      readyState: HTMLMediaElement.HAVE_CURRENT_DATA,
+      requestVideoFrameCallback,
+    } as unknown as HTMLVideoElement
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(() =>
+        Promise.resolve({ close: vi.fn() } as unknown as ImageBitmap),
+      ),
+    )
+    let rejectFirst: (error: Error) => void = () => undefined
+    const firstDetection = new Promise<never>((_resolve, reject) => {
+      rejectFirst = reject
+    })
+    const detect = vi
+      .fn<HandTrackerPort["detect"]>()
+      .mockReturnValueOnce(firstDetection)
+      .mockResolvedValueOnce({
+        ...deterministicTrackingResult,
+        frameId: 2,
+        timestampMs: 32,
+      })
+    const tracker: HandTrackerPort = {
+      detect,
+      dispose: vi.fn(),
+      initialize: vi.fn(() => Promise.resolve()),
+    }
+    const onError = vi.fn()
+    const session = new HandTrackingSession(video, tracker, {
+      onError,
+      onResult: vi.fn(),
+    })
+    await session.start(options)
+
+    videoCallbacks[0]?.(0, { mediaTime: 0.016 } as VideoFrameCallbackMetadata)
+    await vi.waitFor(() =>
+      expect(requestVideoFrameCallback).toHaveBeenCalledTimes(2),
+    )
+    videoCallbacks[1]?.(0, { mediaTime: 0.032 } as VideoFrameCallbackMetadata)
+    await vi.waitFor(() => expect(detect).toHaveBeenCalledTimes(2))
+
+    rejectFirst(new DroppedFrameError())
+    await Promise.resolve()
+    expect(onError).not.toHaveBeenCalled()
     session.dispose()
     vi.unstubAllGlobals()
   })

--- a/src/infrastructure/mediapipe/hand-tracking-session.ts
+++ b/src/infrastructure/mediapipe/hand-tracking-session.ts
@@ -16,11 +16,17 @@ type SessionCallbacks = {
 export function classifyTrackingQuality(
   result: HandTrackingResult,
 ): TrackingQuality {
-  const confidence = result.hands[0]?.confidence
-  if (confidence === undefined) {
+  const hand = result.hands[0]
+  if (!hand) {
     return "lost"
   }
-  return confidence >= 0.75 ? "reliable" : "uncertain"
+  const hasCompleteFiniteGeometry =
+    hand.landmarks.length >= 21 &&
+    hand.landmarks.every(
+      ({ x, y, z }) =>
+        Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z),
+    )
+  return hasCompleteFiniteGeometry ? "reliable" : "uncertain"
 }
 
 export class HandTrackingSession {

--- a/src/infrastructure/mediapipe/hand-tracking-session.ts
+++ b/src/infrastructure/mediapipe/hand-tracking-session.ts
@@ -4,6 +4,7 @@ import type {
   HandTrackerPort,
   HandTrackingResult,
 } from "@/infrastructure/mediapipe/hand-tracker-port"
+import { DroppedFrameError } from "@/infrastructure/mediapipe/worker-hand-tracker"
 
 export type TrackingQuality = "reliable" | "uncertain" | "lost"
 
@@ -63,7 +64,11 @@ export class HandTrackingSession {
   }
 
   private scheduleFrame(): void {
-    if (this.disposed) {
+    if (
+      this.disposed ||
+      this.videoFrameCallbackId !== null ||
+      this.animationFrameId !== null
+    ) {
       return
     }
 
@@ -99,18 +104,25 @@ export class HandTrackingSession {
       }
 
       this.frameId += 1
-      const result = await this.tracker.detect(frame, this.frameId, timestampMs)
+      const detection = this.tracker.detect(frame, this.frameId, timestampMs)
+      this.scheduleFrame()
+      const result = await detection
       if (!this.disposed) {
         this.callbacks.onResult(result, classifyTrackingQuality(result))
       }
     } catch (error) {
-      if (!this.disposed) {
+      if (!this.disposed && !(error instanceof DroppedFrameError)) {
         this.callbacks.onError(
           error instanceof Error ? error : new Error("Hand tracking failed"),
         )
       }
     } finally {
-      this.scheduleFrame()
+      if (
+        this.videoFrameCallbackId === null &&
+        this.animationFrameId === null
+      ) {
+        this.scheduleFrame()
+      }
     }
   }
 }

--- a/src/infrastructure/mediapipe/landmark-overlay-renderer.ts
+++ b/src/infrastructure/mediapipe/landmark-overlay-renderer.ts
@@ -28,6 +28,7 @@ export class LandmarkOverlayRenderer {
   constructor(
     private readonly canvas: HTMLCanvasElement,
     private readonly video: HTMLVideoElement,
+    private readonly fit: "cover" | "contain" = "cover",
   ) {}
 
   render(result: HandTrackingResult): void {
@@ -90,10 +91,12 @@ export class LandmarkOverlayRenderer {
   private mapMirroredPoint(x: number, y: number) {
     const sourceWidth = Math.max(1, this.video.videoWidth)
     const sourceHeight = Math.max(1, this.video.videoHeight)
-    const scale = Math.max(
+    const scales = [
       this.canvas.width / sourceWidth,
       this.canvas.height / sourceHeight,
-    )
+    ]
+    const scale =
+      this.fit === "contain" ? Math.min(...scales) : Math.max(...scales)
     const offsetX = (this.canvas.width - sourceWidth * scale) / 2
     const offsetY = (this.canvas.height - sourceHeight * scale) / 2
 

--- a/src/infrastructure/mediapipe/mediapipe-hand-tracker.test.ts
+++ b/src/infrastructure/mediapipe/mediapipe-hand-tracker.test.ts
@@ -80,13 +80,13 @@ describe("MediaPipeHandTracker", () => {
       hands: [
         {
           handedness: "Left",
-          confidence: 0.96,
+          handednessConfidence: 0.96,
           landmarks: [{ x: 0.1, y: 0.2, z: -0.01, visibility: 0.9 }],
           worldLandmarks: [{ x: 0.01, y: 0.02, z: -0.03 }],
         },
         {
           handedness: "Unknown",
-          confidence: 0,
+          handednessConfidence: 0,
           landmarks: [{ x: 0.4, y: 0.5, z: -0.02 }],
           worldLandmarks: [],
         },

--- a/src/infrastructure/mediapipe/mediapipe-hand-tracker.test.ts
+++ b/src/infrastructure/mediapipe/mediapipe-hand-tracker.test.ts
@@ -95,6 +95,49 @@ describe("MediaPipeHandTracker", () => {
     expect(mediaPipe.detectForVideo).toHaveBeenCalledWith(frame, 80)
   })
 
+  it("falls back to the CPU delegate when GPU initialization fails", async () => {
+    mediaPipe.createFromOptions
+      .mockRejectedValueOnce(new Error("WebGL unavailable"))
+      .mockResolvedValueOnce({
+        close: mediaPipe.close,
+        detectForVideo: mediaPipe.detectForVideo,
+      })
+    const tracker = new MediaPipeHandTracker()
+
+    await tracker.initialize({ ...options, delegate: "GPU" })
+
+    expect(mediaPipe.createFromOptions).toHaveBeenNthCalledWith(
+      1,
+      { fileset: true },
+      {
+        baseOptions: {
+          delegate: "GPU",
+          modelAssetPath: "http://localhost/vision/hand_landmarker.task",
+        },
+        minHandDetectionConfidence: 0.5,
+        minHandPresenceConfidence: 0.6,
+        minTrackingConfidence: 0.7,
+        numHands: 1,
+        runningMode: "VIDEO",
+      },
+    )
+    expect(mediaPipe.createFromOptions).toHaveBeenNthCalledWith(
+      2,
+      { fileset: true },
+      {
+        baseOptions: {
+          delegate: "CPU",
+          modelAssetPath: "http://localhost/vision/hand_landmarker.task",
+        },
+        minHandDetectionConfidence: 0.5,
+        minHandPresenceConfidence: 0.6,
+        minTrackingConfidence: 0.7,
+        numHands: 1,
+        runningMode: "VIDEO",
+      },
+    )
+  })
+
   it("rejects detection before initialization and disposes idempotently", async () => {
     const tracker = new MediaPipeHandTracker()
 

--- a/src/infrastructure/mediapipe/mediapipe-hand-tracker.ts
+++ b/src/infrastructure/mediapipe/mediapipe-hand-tracker.ts
@@ -34,7 +34,7 @@ function toTrackedHands(result: HandLandmarkerResult): TrackedHand[] {
     const handedness = result.handedness[index]?.[0]
     return {
       handedness: normalizeHandedness(handedness?.categoryName),
-      confidence: handedness?.score ?? 0,
+      handednessConfidence: handedness?.score ?? 0,
       landmarks: landmarks.map(copyLandmark),
       worldLandmarks: (result.worldLandmarks[index] ?? []).map(copyLandmark),
     }

--- a/src/infrastructure/mediapipe/mediapipe-hand-tracker.ts
+++ b/src/infrastructure/mediapipe/mediapipe-hand-tracker.ts
@@ -50,16 +50,29 @@ export class MediaPipeHandTracker implements HandTrackerPort {
       options.wasmRootUrl,
       true,
     )
-    this.landmarker = await HandLandmarker.createFromOptions(fileset, {
+    const createOptions = (delegate?: "CPU" | "GPU") => ({
       baseOptions: {
         modelAssetPath: options.modelAssetUrl,
+        ...(delegate ? { delegate } : {}),
       },
       minHandDetectionConfidence: options.minDetectionConfidence,
       minHandPresenceConfidence: options.minPresenceConfidence,
       minTrackingConfidence: options.minTrackingConfidence,
       numHands: options.maxHands,
-      runningMode: "VIDEO",
+      runningMode: "VIDEO" as const,
     })
+    try {
+      this.landmarker = await HandLandmarker.createFromOptions(
+        fileset,
+        createOptions(options.delegate),
+      )
+    } catch (error) {
+      if (options.delegate !== "GPU") throw error
+      this.landmarker = await HandLandmarker.createFromOptions(
+        fileset,
+        createOptions("CPU"),
+      )
+    }
   }
 
   detect(

--- a/src/infrastructure/mediapipe/vision-worker-runtime.test.ts
+++ b/src/infrastructure/mediapipe/vision-worker-runtime.test.ts
@@ -176,6 +176,11 @@ describe("createVisionWorkerRuntime", () => {
 
     expect(detect).toHaveBeenCalledTimes(1)
     expect(obsolete.close).toHaveBeenCalledOnce()
+    expect(messages).toContainEqual({
+      version: 1,
+      type: "DROPPED",
+      frameId: 2,
+    })
     clock = 8
     firstResult.resolve({ ...deterministicTrackingResult, frameId: 1 })
     await vi.waitFor(() => expect(detect).toHaveBeenCalledTimes(2))

--- a/src/infrastructure/mediapipe/vision-worker-runtime.ts
+++ b/src/infrastructure/mediapipe/vision-worker-runtime.ts
@@ -136,6 +136,11 @@ export function createVisionWorkerRuntime(
           if (queuedFrame) {
             queuedFrame.frame.close()
             droppedFrames += 1
+            scope.postMessage({
+              version: VISION_PROTOCOL_VERSION,
+              type: "DROPPED",
+              frameId: queuedFrame.frameId,
+            })
           }
           queuedFrame = message
         } else {

--- a/src/infrastructure/mediapipe/worker-hand-tracker.test.ts
+++ b/src/infrastructure/mediapipe/worker-hand-tracker.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
 import type { HandTrackerOptions } from "@/infrastructure/mediapipe/hand-tracker-port"
-import { WorkerHandTracker } from "@/infrastructure/mediapipe/worker-hand-tracker"
+import {
+  DroppedFrameError,
+  WorkerHandTracker,
+} from "@/infrastructure/mediapipe/worker-hand-tracker"
 import { deterministicTrackingResult } from "@/test/fixtures/hand-landmarks"
 
 const options: HandTrackerOptions = {
@@ -106,6 +109,20 @@ describe("WorkerHandTracker", () => {
     })
 
     await expect(detection).rejects.toThrow("Inference failed")
+  })
+
+  it("releases a superseded detection without reporting a tracker failure", async () => {
+    const { worker } = createWorker()
+    const tracker = new WorkerHandTracker(() => worker)
+    const detection = tracker.detect(
+      { close: vi.fn() } as unknown as ImageBitmap,
+      10,
+      180,
+    )
+
+    emit(worker, { version: 1, type: "DROPPED", frameId: 10 })
+
+    await expect(detection).rejects.toBeInstanceOf(DroppedFrameError)
   })
 
   it("rejects pending work after an invalid response or worker crash", async () => {

--- a/src/infrastructure/mediapipe/worker-hand-tracker.ts
+++ b/src/infrastructure/mediapipe/worker-hand-tracker.ts
@@ -26,6 +26,13 @@ function createVisionWorker(): Worker {
   )
 }
 
+export class DroppedFrameError extends Error {
+  constructor() {
+    super("Vision frame superseded by a newer frame")
+    this.name = "DroppedFrameError"
+  }
+}
+
 export class WorkerHandTracker implements HandTrackerPort {
   private readonly worker: WorkerPort
   private initializePromise: Promise<void> | null = null
@@ -131,6 +138,10 @@ export class WorkerHandTracker implements HandTrackerPort {
       }
       case "METRICS":
         this.onMetrics?.(value.metrics)
+        break
+      case "DROPPED":
+        this.pendingFrames.get(value.frameId)?.reject(new DroppedFrameError())
+        this.pendingFrames.delete(value.frameId)
         break
       case "ERROR": {
         const error = new Error(value.message)

--- a/src/infrastructure/mediapipe/worker-protocol.test.ts
+++ b/src/infrastructure/mediapipe/worker-protocol.test.ts
@@ -37,6 +37,9 @@ describe("vision worker protocol", () => {
     expect(isVisionWorkerResponse({ version: 2, type: "RESULT" })).toBe(false)
     expect(isVisionWorkerResponse({ version: 1, type: "UNKNOWN" })).toBe(false)
     expect(isVisionWorkerResponse({ version: 1, type: "METRICS" })).toBe(true)
+    expect(
+      isVisionWorkerResponse({ version: 1, type: "DROPPED", frameId: 4 }),
+    ).toBe(true)
   })
 
   it("provides deterministic 21-point landmark fixtures", () => {

--- a/src/infrastructure/mediapipe/worker-protocol.test.ts
+++ b/src/infrastructure/mediapipe/worker-protocol.test.ts
@@ -42,7 +42,9 @@ describe("vision worker protocol", () => {
   it("provides deterministic 21-point landmark fixtures", () => {
     expect(openHandLandmarks).toHaveLength(21)
     expect(openHandLandmarks[0]).toEqual({ x: 0.3, y: 0.8, z: 0 })
-    expect(deterministicTrackingResult.hands[0]?.confidence).toBe(0.98)
+    expect(deterministicTrackingResult.hands[0]?.handednessConfidence).toBe(
+      0.98,
+    )
   })
 
   it("provides a disposable fake tracker", async () => {

--- a/src/infrastructure/mediapipe/worker-protocol.ts
+++ b/src/infrastructure/mediapipe/worker-protocol.ts
@@ -46,6 +46,12 @@ export type VisionMetricsResponse = {
   metrics: HandTrackerMetrics
 }
 
+export type VisionDroppedResponse = {
+  version: typeof VISION_PROTOCOL_VERSION
+  type: "DROPPED"
+  frameId: number
+}
+
 export type VisionErrorResponse = {
   version: typeof VISION_PROTOCOL_VERSION
   type: "ERROR"
@@ -65,6 +71,7 @@ export type VisionWorkerResponse =
   | VisionInitResponse
   | VisionResultResponse
   | VisionMetricsResponse
+  | VisionDroppedResponse
   | VisionErrorResponse
   | VisionDisposeResponse
 
@@ -81,6 +88,7 @@ export function isVisionWorkerResponse(
     (candidate.type === "INIT" ||
       candidate.type === "RESULT" ||
       candidate.type === "METRICS" ||
+      candidate.type === "DROPPED" ||
       candidate.type === "ERROR" ||
       candidate.type === "DISPOSE")
   )

--- a/src/test/fixtures/gesture-landmarks.ts
+++ b/src/test/fixtures/gesture-landmarks.ts
@@ -70,11 +70,11 @@ export const uncertainGestureLandmarks = pose({
 
 export function handFromGestureFixture(
   landmarks: NormalizedLandmark[],
-  confidence = 0.98,
+  handednessConfidence = 0.98,
 ): TrackedHand {
   return {
     handedness: "Right",
-    confidence,
+    handednessConfidence,
     landmarks,
     worldLandmarks: landmarks,
   }

--- a/src/test/fixtures/hand-landmarks.ts
+++ b/src/test/fixtures/hand-landmarks.ts
@@ -15,7 +15,7 @@ export const openHandLandmarks: NormalizedLandmark[] = Array.from(
 
 export const trackedRightHand: TrackedHand = {
   handedness: "Right",
-  confidence: 0.98,
+  handednessConfidence: 0.98,
   landmarks: openHandLandmarks,
   worldLandmarks: openHandLandmarks.map((landmark) => ({
     x: (landmark.x - 0.5) * 0.15,


### PR DESCRIPTION
## Résumé

- valide trois étapes avec les gestes réellement détectés et stabilisés : main visible, pincement, main ouverte
- conserve une prévisualisation caméra flottante et stable pendant la calibration et le dessin
- projette la main sur toute la toile sans rupture lors des ambiguïtés brèves
- sépare la détection du pincement, la stabilisation du pointeur et le rendu Canvas
- ajoute les modes de précision Libre, Stabilisé et Formes
- régularise de façon réversible les lignes, cercles, ellipses et rectangles
- mémorise uniquement la complétion du tutoriel, sans donnée biométrique ou vidéo

## Vérification automatisée

- `pnpm validate`
- 26 fichiers de tests, 176 tests réussis
- lint, TypeScript et build Vite réussis
- CI GitHub : `quality`, `unit-tests` et `build` réussis
- contrôle navigateur local sans erreur ni avertissement applicatif

## Vérification manuelle

- [x] terminer les trois étapes avec une vraie webcam
- [x] confirmer que la prévisualisation reste en haut à droite pendant toute la calibration
- [x] confirmer que la prévisualisation redevient circulaire après la calibration
- [x] dessiner plusieurs cercles complets sans rupture lors d’une hésitation très brève
- [x] confirmer qu’une ouverture volontaire de la main arrête rapidement le trait
- [x] dessiner jusqu’aux différentes zones de la toile sans atteindre physiquement les bords de l’image caméra
- [x] recharger la page et vérifier que le tutoriel reste terminé
- [x] utiliser « Revoir les gestes » et vérifier que la calibration recommence
- [x] vérifier les modes Libre, Stabilisé et Formes avec des tracés réels
- [x] confirmer la correction réversible des lignes, cercles, ellipses et rectangles