### PR TITLE
feat: complete drawing controls and PNG export

### DIFF
--- a/src/core/drawing/canvas-drawing-controller.ts
+++ b/src/core/drawing/canvas-drawing-controller.ts
@@ -31,6 +31,12 @@ export type StrokeAssistanceFeedback = {
   confidence: number
 }
 
+export type DrawingHistoryAvailability = {
+  canUndo: boolean
+  canRedo: boolean
+  canClear: boolean
+}
+
 export class CanvasDrawingController {
   readonly #renderer: TwoLayerCanvasRenderer
   #history: DrawingHistory
@@ -40,6 +46,8 @@ export class CanvasDrawingController {
   #activeStroke: Stroke | null = null
   #nextStrokeId = 1
   #onAssistance: ((feedback: StrokeAssistanceFeedback) => void) | null = null
+  #onHistoryChange:
+    ((availability: DrawingHistoryAvailability) => void) | null = null
 
   constructor(renderer: TwoLayerCanvasRenderer, historyLimit = 50) {
     this.#renderer = renderer
@@ -48,6 +56,14 @@ export class CanvasDrawingController {
 
   get document() {
     return this.#history.present
+  }
+
+  get historyAvailability(): DrawingHistoryAvailability {
+    return {
+      canUndo: this.#history.past.length > 0,
+      canRedo: this.#history.future.length > 0,
+      canClear: this.#history.present.strokes.length > 0,
+    }
   }
 
   setBounds(bounds: CanvasBounds) {
@@ -68,6 +84,13 @@ export class CanvasDrawingController {
     listener: ((feedback: StrokeAssistanceFeedback) => void) | null,
   ) {
     this.#onAssistance = listener
+  }
+
+  setHistoryListener(
+    listener: ((availability: DrawingHistoryAvailability) => void) | null,
+  ) {
+    this.#onHistoryChange = listener
+    listener?.(this.historyAvailability)
   }
 
   handle(intention: DrawingIntention) {
@@ -109,13 +132,26 @@ export class CanvasDrawingController {
   }
 
   undo() {
+    this.#finishStroke()
     this.#history = undoDrawing(this.#history)
     this.#renderer.setDocument(this.#history.present)
+    this.#emitHistoryChange()
   }
 
   redo() {
+    this.#finishStroke()
     this.#history = redoDrawing(this.#history)
     this.#renderer.setDocument(this.#history.present)
+    this.#emitHistoryChange()
+  }
+
+  clear() {
+    this.#activeStroke = null
+    this.#renderer.setPreviewStroke(null)
+    const next = applyDrawingCommand(this.#history.present, { type: "CLEAR" })
+    this.#history = recordDrawing(this.#history, next)
+    this.#renderer.setDocument(this.#history.present)
+    this.#emitHistoryChange()
   }
 
   revertAssistance(strokeId: string) {
@@ -133,6 +169,7 @@ export class CanvasDrawingController {
     }
     this.#history = recordDrawing(this.#history, { strokes })
     this.#renderer.setDocument(this.#history.present)
+    this.#emitHistoryChange()
     return true
   }
 
@@ -151,12 +188,17 @@ export class CanvasDrawingController {
     this.#activeStroke = null
     this.#renderer.setPreviewStroke(null)
     this.#renderer.setDocument(this.#history.present)
+    this.#emitHistoryChange()
     if (assisted.correction) {
       this.#onAssistance?.({
         strokeId: assisted.stroke.id,
         ...assisted.correction,
       })
     }
+  }
+
+  #emitHistoryChange() {
+    this.#onHistoryChange?.(this.historyAvailability)
   }
 
   #toLocalPoint(point: { x: number; y: number }) {

--- a/src/core/drawing/canvas-drawing-controller.ts
+++ b/src/core/drawing/canvas-drawing-controller.ts
@@ -154,6 +154,11 @@ export class CanvasDrawingController {
     this.#emitHistoryChange()
   }
 
+  exportPng() {
+    this.#finishStroke()
+    return this.#renderer.toPngBlob()
+  }
+
   revertAssistance(strokeId: string) {
     const strokeIndex = this.#history.present.strokes.findIndex(
       (stroke) => stroke.id === strokeId && stroke.assistance,

--- a/src/core/drawing/canvas-png-export.test.ts
+++ b/src/core/drawing/canvas-png-export.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { canvasToPngBlob } from "./canvas-png-export"
+
+describe("canvasToPngBlob", () => {
+  it("composes ink over a white background at physical resolution", async () => {
+    const source = { width: 1600, height: 900 } as HTMLCanvasElement
+    const blob = new Blob(["png"], { type: "image/png" })
+    const context = {
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      fillStyle: "",
+    }
+    const output = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => context),
+      toBlob: vi.fn((callback: BlobCallback, type?: string) => {
+        expect(type).toBe("image/png")
+        callback(blob)
+      }),
+    } as unknown as HTMLCanvasElement
+
+    await expect(canvasToPngBlob(source, () => output)).resolves.toBe(blob)
+    expect(output.width).toBe(1600)
+    expect(output.height).toBe(900)
+    expect(context.fillStyle).toBe("#ffffff")
+    expect(context.fillRect).toHaveBeenCalledWith(0, 0, 1600, 900)
+    expect(context.drawImage).toHaveBeenCalledWith(source, 0, 0)
+  })
+
+  it("reports unsupported or failed PNG encoders", async () => {
+    const source = { width: 10, height: 10 } as HTMLCanvasElement
+    const withoutContext = {
+      getContext: () => null,
+    } as unknown as HTMLCanvasElement
+    await expect(canvasToPngBlob(source, () => withoutContext)).rejects.toThrow(
+      "Canvas 2D support",
+    )
+
+    const withoutBlob = {
+      getContext: () => ({
+        drawImage: vi.fn(),
+        fillRect: vi.fn(),
+        fillStyle: "",
+      }),
+      toBlob: (callback: BlobCallback) => callback(null),
+    } as unknown as HTMLCanvasElement
+    await expect(canvasToPngBlob(source, () => withoutBlob)).rejects.toThrow(
+      "could not encode",
+    )
+  })
+})

--- a/src/core/drawing/canvas-png-export.ts
+++ b/src/core/drawing/canvas-png-export.ts
@@ -1,0 +1,25 @@
+type CanvasFactory = () => HTMLCanvasElement
+
+export function canvasToPngBlob(
+  source: HTMLCanvasElement,
+  createCanvas: CanvasFactory = () => document.createElement("canvas"),
+) {
+  return new Promise<Blob>((resolve, reject) => {
+    const output = createCanvas()
+    output.width = source.width
+    output.height = source.height
+    const context = output.getContext("2d")
+    if (!context) {
+      reject(new Error("PNG export requires Canvas 2D support"))
+      return
+    }
+
+    context.fillStyle = "#ffffff"
+    context.fillRect(0, 0, output.width, output.height)
+    context.drawImage(source, 0, 0)
+    output.toBlob((blob) => {
+      if (blob) resolve(blob)
+      else reject(new Error("The browser could not encode the PNG"))
+    }, "image/png")
+  })
+}

--- a/src/core/drawing/two-layer-canvas-renderer.test.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.test.ts
@@ -255,6 +255,50 @@ describe("CanvasDrawingController", () => {
     expect(controller.document.strokes).toHaveLength(1)
   })
 
+  it("publishes history availability and records a reversible clear", () => {
+    const harness = createHarness(1)
+    const controller = new CanvasDrawingController(harness.renderer)
+    const onHistoryChange = vi.fn()
+    controller.setBounds({ left: 0, top: 0, width: 100, height: 100 })
+    controller.setHistoryListener(onHistoryChange)
+
+    expect(onHistoryChange).toHaveBeenLastCalledWith({
+      canUndo: false,
+      canRedo: false,
+      canClear: false,
+    })
+
+    controller.handle({
+      version: 1,
+      type: "DRAW_START",
+      point: { x: 20, y: 20 },
+      timestampMs: 0,
+    })
+    controller.handle({
+      version: 1,
+      type: "DRAW_END",
+      point: { x: 20, y: 20 },
+      timestampMs: 1,
+    })
+    expect(onHistoryChange).toHaveBeenLastCalledWith({
+      canUndo: true,
+      canRedo: false,
+      canClear: true,
+    })
+
+    controller.clear()
+    expect(controller.document.strokes).toEqual([])
+    expect(controller.historyAvailability).toEqual({
+      canUndo: true,
+      canRedo: false,
+      canClear: false,
+    })
+
+    controller.undo()
+    expect(controller.document.strokes).toHaveLength(1)
+    expect(controller.historyAvailability.canRedo).toBe(true)
+  })
+
   it("applies style, clamps points, and finishes explicitly", () => {
     const harness = createHarness(1)
     const controller = new CanvasDrawingController(harness.renderer)

--- a/src/core/drawing/two-layer-canvas-renderer.ts
+++ b/src/core/drawing/two-layer-canvas-renderer.ts
@@ -2,6 +2,7 @@ import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
 
 import type { DrawingDocument, Stroke } from "./drawing-model"
 import { emptyDrawingDocument } from "./drawing-model"
+import { canvasToPngBlob } from "./canvas-png-export"
 
 type FrameScheduler = (callback: FrameRequestCallback) => number
 
@@ -76,6 +77,11 @@ export class TwoLayerCanvasRenderer {
   setPreviewStroke(stroke: Stroke | null) {
     this.#previewStroke = stroke
     this.requestRender()
+  }
+
+  toPngBlob() {
+    this.#render()
+    return canvasToPngBlob(this.#persistentCanvas)
   }
 
   requestRender() {

--- a/src/features/camera/camera-preview.tsx
+++ b/src/features/camera/camera-preview.tsx
@@ -1,3 +1,5 @@
+import { forwardRef, useImperativeHandle } from "react"
+
 import {
   Camera,
   CameraOff,
@@ -24,6 +26,10 @@ type CameraPreviewProps = {
   trackerFactory?: HandTrackerFactory
   onGestureFrame?: GestureFrameListener
   calibrating?: boolean
+}
+
+export type CameraPreviewHandle = {
+  togglePause(): void
 }
 
 const trackingContent = {
@@ -73,12 +79,18 @@ const errorContent = {
   },
 } as const
 
-export function CameraPreview({
-  adapterFactory,
-  trackerFactory,
-  onGestureFrame,
-  calibrating = false,
-}: CameraPreviewProps) {
+export const CameraPreview = forwardRef<
+  CameraPreviewHandle,
+  CameraPreviewProps
+>(function CameraPreview(
+  {
+    adapterFactory,
+    trackerFactory,
+    onGestureFrame,
+    calibrating = false,
+  }: CameraPreviewProps,
+  ref,
+) {
   const {
     devices,
     selectedDeviceId,
@@ -109,6 +121,13 @@ export function CameraPreview({
     state === "failed"
       ? errorContent[state]
       : null
+
+  useImperativeHandle(ref, () => ({
+    togglePause() {
+      if (state === "ready") stop()
+      else if (state === "stopped") void start()
+    },
+  }))
 
   return (
     <section aria-label="Aperçu caméra" className="camera-preview">
@@ -160,7 +179,11 @@ export function CameraPreview({
                 La vidéo reste sur cet appareil et n’est jamais enregistrée.
               </p>
             </div>
-            <Button className="h-11 w-full" onClick={() => void start()}>
+            <Button
+              className="h-11 w-full"
+              data-gesture-control=""
+              onClick={() => void start()}
+            >
               <Video aria-hidden="true" data-icon="inline-start" />
               Activer ma caméra
             </Button>
@@ -220,7 +243,12 @@ export function CameraPreview({
                 </select>
               </label>
             ) : null}
-            <Button variant="ghost" size="sm" onClick={stop}>
+            <Button
+              variant="ghost"
+              size="sm"
+              data-gesture-control=""
+              onClick={stop}
+            >
               Mettre la caméra en pause
             </Button>
           </>
@@ -229,7 +257,11 @@ export function CameraPreview({
         {state === "stopped" ? (
           <>
             <Badge variant="secondary">Caméra en pause</Badge>
-            <Button className="h-11" onClick={() => void start()}>
+            <Button
+              className="h-11"
+              data-gesture-control=""
+              onClick={() => void start()}
+            >
               Reprendre la caméra
             </Button>
           </>
@@ -244,7 +276,11 @@ export function CameraPreview({
                 <p>{error.description}</p>
               </div>
             </div>
-            <Button className="h-11 w-full" onClick={() => void start()}>
+            <Button
+              className="h-11 w-full"
+              data-gesture-control=""
+              onClick={() => void start()}
+            >
               {error.action}
             </Button>
           </div>
@@ -252,4 +288,4 @@ export function CameraPreview({
       </div>
     </section>
   )
-}
+})

--- a/src/features/export/png-download.test.ts
+++ b/src/features/export/png-download.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createPngFilename, downloadPng } from "./png-download"
+
+describe("PNG download", () => {
+  it("creates the contractual timestamped filename", () => {
+    expect(createPngFilename(new Date(2026, 7, 25, 9, 4, 7))).toBe(
+      "drawmotion-2026-08-25-090407.png",
+    )
+  })
+
+  it("downloads an object URL and releases it", async () => {
+    const blob = new Blob(["png"], { type: "image/png" })
+    const createObjectURL = vi.fn(() => "blob:drawmotion")
+    const revokeObjectURL = vi.fn()
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined)
+
+    downloadPng(blob, "drawing.png", document, {
+      createObjectURL,
+      revokeObjectURL,
+    })
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+    const anchor = click.mock.instances[0] as HTMLAnchorElement | undefined
+    expect(anchor?.download).toBe("drawing.png")
+    expect(anchor?.href).toBe("blob:drawmotion")
+    expect(document.body.contains(anchor ?? null)).toBe(false)
+    await Promise.resolve()
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:drawmotion")
+    click.mockRestore()
+  })
+})

--- a/src/features/export/png-download.ts
+++ b/src/features/export/png-download.ts
@@ -1,0 +1,34 @@
+function pad(value: number) {
+  return String(value).padStart(2, "0")
+}
+
+export function createPngFilename(date = new Date()) {
+  const day = [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+  ].join("-")
+  const time = [
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+  ].join("")
+  return `drawmotion-${day}-${time}.png`
+}
+
+export function downloadPng(
+  blob: Blob,
+  filename: string,
+  documentRoot: Document = document,
+  urlApi: Pick<typeof URL, "createObjectURL" | "revokeObjectURL"> = URL,
+) {
+  const objectUrl = urlApi.createObjectURL(blob)
+  const anchor = documentRoot.createElement("a")
+  anchor.href = objectUrl
+  anchor.download = filename
+  anchor.hidden = true
+  documentRoot.body.append(anchor)
+  anchor.click()
+  anchor.remove()
+  queueMicrotask(() => urlApi.revokeObjectURL(objectUrl))
+}

--- a/src/features/toolbar/drawing-tools.ts
+++ b/src/features/toolbar/drawing-tools.ts
@@ -1,0 +1,9 @@
+export const drawingColors = [
+  { name: "Encre", value: "#17171c", className: "text-canvas-foreground" },
+  { name: "Violet", value: "#7c3aed", className: "text-primary" },
+  { name: "Vert", value: "#238554", className: "text-success" },
+  { name: "Orange", value: "#a46c1f", className: "text-warning" },
+] as const
+
+export type DrawingColor = (typeof drawingColors)[number]["value"]
+export type DrawingTool = "pointer" | "pen" | "eraser"

--- a/src/features/toolbar/gesture-control-hit-test.test.ts
+++ b/src/features/toolbar/gesture-control-hit-test.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { findGestureControlAtPoint } from "./gesture-control-hit-test"
+
+describe("findGestureControlAtPoint", () => {
+  it("finds the enabled control under a gesture pointer", () => {
+    const button = document.createElement("button")
+    button.dataset.gestureControl = ""
+    const icon = document.createElement("span")
+    button.append(icon)
+
+    expect(
+      findGestureControlAtPoint(
+        { x: 20, y: 40 },
+        { elementFromPoint: () => icon },
+      ),
+    ).toBe(button)
+  })
+
+  it("ignores disabled and unrelated elements", () => {
+    const button = document.createElement("button")
+    button.dataset.gestureControl = ""
+    button.disabled = true
+    const unrelated = document.createElement("span")
+
+    expect(
+      findGestureControlAtPoint(
+        { x: 0, y: 0 },
+        { elementFromPoint: () => button },
+      ),
+    ).toBeNull()
+    expect(
+      findGestureControlAtPoint(
+        { x: 0, y: 0 },
+        { elementFromPoint: () => unrelated },
+      ),
+    ).toBeNull()
+  })
+})

--- a/src/features/toolbar/gesture-control-hit-test.ts
+++ b/src/features/toolbar/gesture-control-hit-test.ts
@@ -1,0 +1,17 @@
+import type { CanvasPoint } from "@/core/geometry/coordinate-mapping"
+
+export function findGestureControlAtPoint(
+  point: CanvasPoint,
+  documentRoot: Pick<Document, "elementFromPoint"> = document,
+) {
+  const element = documentRoot.elementFromPoint(point.x, point.y)
+  const control = element?.closest<HTMLElement>("[data-gesture-control]")
+  if (
+    !control ||
+    control.getAttribute("aria-disabled") === "true" ||
+    (control instanceof HTMLButtonElement && control.disabled)
+  ) {
+    return null
+  }
+  return control
+}

--- a/src/features/toolbar/tool-button.tsx
+++ b/src/features/toolbar/tool-button.tsx
@@ -28,6 +28,7 @@ export function ToolButton({
           <Button
             aria-label={label}
             className={cn("size-11", className)}
+            data-gesture-control=""
             size="icon-lg"
             {...props}
           />

--- a/src/features/toolbar/tool-rail.test.tsx
+++ b/src/features/toolbar/tool-rail.test.tsx
@@ -40,6 +40,9 @@ describe("ToolRail", () => {
       name: "Épaisseur du trait",
     })
     expect(slider.querySelector('[data-slot="slider-thumb"]')).not.toBeNull()
-    expect(onThicknessChange).not.toHaveBeenCalled()
+    const preset = screen.getByRole("button", { name: "12 px" })
+    expect(preset).toHaveAttribute("data-gesture-control")
+    await user.click(preset)
+    expect(onThicknessChange).toHaveBeenCalledWith(12)
   })
 })

--- a/src/features/toolbar/tool-rail.test.tsx
+++ b/src/features/toolbar/tool-rail.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { AppProviders } from "@/app/providers"
+import { ToolRail } from "@/features/toolbar/tool-rail"
+
+describe("ToolRail", () => {
+  it("exposes real pen, eraser, color and thickness controls", async () => {
+    const user = userEvent.setup()
+    const onToolChange = vi.fn()
+    const onColorChange = vi.fn()
+    const onThicknessChange = vi.fn()
+    render(
+      <AppProviders>
+        <ToolRail
+          activeTool="pen"
+          color="#17171c"
+          thickness={8}
+          onToolChange={onToolChange}
+          onColorChange={onColorChange}
+          onThicknessChange={onThicknessChange}
+        />
+      </AppProviders>,
+    )
+
+    expect(screen.getByRole("button", { name: "Stylo" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    await user.click(screen.getByRole("button", { name: "Gomme" }))
+    expect(onToolChange).toHaveBeenCalledWith("eraser")
+
+    await user.click(screen.getByRole("button", { name: "Violet" }))
+    expect(onColorChange).toHaveBeenCalledWith("#7c3aed")
+    expect(onToolChange).toHaveBeenLastCalledWith("pen")
+
+    await user.click(screen.getByRole("button", { name: "Épaisseur 8 pixels" }))
+    const slider = screen.getByRole("group", {
+      name: "Épaisseur du trait",
+    })
+    expect(slider.querySelector('[data-slot="slider-thumb"]')).not.toBeNull()
+    expect(onThicknessChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/toolbar/tool-rail.tsx
+++ b/src/features/toolbar/tool-rail.tsx
@@ -1,27 +1,43 @@
-import { Circle, Eraser, Minus, MousePointer2, PenLine } from "lucide-react"
+import { Circle, Eraser, MousePointer2, PenLine } from "lucide-react"
 
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { Separator } from "@/components/ui/separator"
+import { Slider } from "@/components/ui/slider"
+import {
+  drawingColors,
+  type DrawingColor,
+  type DrawingTool,
+} from "@/features/toolbar/drawing-tools"
 import { ToolButton } from "@/features/toolbar/tool-button"
-
-export type DrawingTool = "pointer" | "pen" | "eraser"
 
 type ToolRailProps = {
   activeTool: DrawingTool
+  color: DrawingColor
+  thickness: number
   onToolChange: (tool: DrawingTool) => void
+  onColorChange: (color: DrawingColor) => void
+  onThicknessChange: (thickness: number) => void
 }
 
-const colors = [
-  { name: "Encre", className: "text-canvas-foreground" },
-  { name: "Violet", className: "text-primary" },
-  { name: "Vert", className: "text-success" },
-  { name: "Orange", className: "text-warning" },
-]
-
-export function ToolRail({ activeTool, onToolChange }: ToolRailProps) {
+export function ToolRail({
+  activeTool,
+  color,
+  thickness,
+  onToolChange,
+  onColorChange,
+  onThicknessChange,
+}: ToolRailProps) {
   return (
-    <aside aria-label="Outils de dessin simulés" className="tool-rail">
+    <aside aria-label="Outils de dessin" className="tool-rail">
       <ToolButton
-        label="Pointeur simulé"
+        label="Pointeur"
         variant={activeTool === "pointer" ? "default" : "ghost"}
         aria-pressed={activeTool === "pointer"}
         onClick={() => onToolChange("pointer")}
@@ -29,7 +45,7 @@ export function ToolRail({ activeTool, onToolChange }: ToolRailProps) {
         <MousePointer2 aria-hidden="true" />
       </ToolButton>
       <ToolButton
-        label="Stylo simulé"
+        label="Stylo"
         shortcut="P"
         variant={activeTool === "pen" ? "default" : "ghost"}
         aria-pressed={activeTool === "pen"}
@@ -38,7 +54,7 @@ export function ToolRail({ activeTool, onToolChange }: ToolRailProps) {
         <PenLine aria-hidden="true" />
       </ToolButton>
       <ToolButton
-        label="Gomme simulée"
+        label="Gomme"
         shortcut="E"
         variant={activeTool === "eraser" ? "default" : "ghost"}
         aria-pressed={activeTool === "eraser"}
@@ -49,29 +65,60 @@ export function ToolRail({ activeTool, onToolChange }: ToolRailProps) {
 
       <Separator className="my-1 w-8" />
 
-      <ToolButton
-        label="Épaisseur — bientôt disponible"
-        variant="ghost"
-        disabled
-      >
-        <Minus aria-hidden="true" className="stroke-[3]" />
-      </ToolButton>
+      <Popover>
+        <PopoverTrigger
+          render={
+            <ToolButton label={`Épaisseur ${thickness} pixels`} variant="ghost">
+              <span
+                aria-hidden="true"
+                className="drawing-thickness-preview"
+                style={{ width: Math.min(22, thickness) }}
+              />
+            </ToolButton>
+          }
+        />
+        <PopoverContent side="right" align="center" className="w-64 gap-4 p-4">
+          <PopoverHeader>
+            <PopoverTitle>Épaisseur du trait</PopoverTitle>
+            <PopoverDescription>
+              {thickness} pixels à la résolution de référence
+            </PopoverDescription>
+          </PopoverHeader>
+          <Slider
+            aria-label="Épaisseur du trait"
+            min={2}
+            max={24}
+            step={2}
+            value={[thickness]}
+            onValueChange={(value) => {
+              const nextThickness = typeof value === "number" ? value : value[0]
+
+              if (nextThickness !== undefined) {
+                onThicknessChange(nextThickness)
+              }
+            }}
+          />
+        </PopoverContent>
+      </Popover>
 
       <div
         className="mt-auto flex flex-col gap-2"
-        aria-label="Couleurs simulées"
+        aria-label="Couleurs du trait"
       >
-        {colors.map((color, index) => (
+        {drawingColors.map((drawingColor) => (
           <ToolButton
-            key={color.name}
-            label={`${color.name} — sélection simulée`}
+            key={drawingColor.value}
+            label={drawingColor.name}
             variant="ghost"
-            aria-pressed={index === 0}
-            disabled={index !== 0}
+            aria-pressed={color === drawingColor.value}
+            onClick={() => {
+              onColorChange(drawingColor.value)
+              onToolChange("pen")
+            }}
           >
             <Circle
               aria-hidden="true"
-              className={`${color.className} fill-current stroke-current`}
+              className={`${drawingColor.className} fill-current stroke-current`}
             />
           </ToolButton>
         ))}

--- a/src/features/toolbar/tool-rail.tsx
+++ b/src/features/toolbar/tool-rail.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTitle,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Slider } from "@/components/ui/slider"
 import {
@@ -98,6 +99,24 @@ export function ToolRail({
               }
             }}
           />
+          <div
+            className="grid grid-cols-4 gap-2"
+            aria-label="Épaisseurs rapides"
+          >
+            {[4, 8, 12, 18].map((preset) => (
+              <Button
+                key={preset}
+                type="button"
+                size="sm"
+                variant={thickness === preset ? "default" : "outline"}
+                aria-pressed={thickness === preset}
+                data-gesture-control=""
+                onClick={() => onThicknessChange(preset)}
+              >
+                {preset} px
+              </Button>
+            ))}
+          </div>
         </PopoverContent>
       </Popover>
 

--- a/src/features/toolbar/top-bar.test.tsx
+++ b/src/features/toolbar/top-bar.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { AppProviders } from "@/app/providers"
+import { TopBar } from "@/features/toolbar/top-bar"
+
+function renderTopBar(overrides: Partial<Parameters<typeof TopBar>[0]> = {}) {
+  const props = {
+    canUndo: true,
+    canRedo: true,
+    canClear: true,
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onClear: vi.fn(),
+    ...overrides,
+  }
+  render(
+    <AppProviders>
+      <TopBar {...props} />
+    </AppProviders>,
+  )
+  return props
+}
+
+describe("TopBar", () => {
+  it("disables unavailable history actions", () => {
+    renderTopBar({ canUndo: false, canRedo: false, canClear: false })
+
+    expect(screen.getByRole("button", { name: "Annuler" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Rétablir" })).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Effacer la toile" }),
+    ).toBeDisabled()
+  })
+
+  it("runs history actions and confirms a destructive clear", async () => {
+    const user = userEvent.setup()
+    const props = renderTopBar()
+
+    await user.click(screen.getByRole("button", { name: "Annuler" }))
+    await user.click(screen.getByRole("button", { name: "Rétablir" }))
+    expect(props.onUndo).toHaveBeenCalledOnce()
+    expect(props.onRedo).toHaveBeenCalledOnce()
+
+    await user.click(screen.getByRole("button", { name: "Effacer la toile" }))
+    const dialog = screen.getByRole("alertdialog", {
+      name: "Effacer tout le dessin ?",
+    })
+    const confirm = within(dialog).getByRole("button", {
+      name: "Effacer la toile",
+    })
+    expect(confirm).toHaveAttribute("data-gesture-control")
+    expect(props.onClear).not.toHaveBeenCalled()
+
+    await user.click(confirm)
+    expect(props.onClear).toHaveBeenCalledOnce()
+    expect(dialog).not.toBeInTheDocument()
+  })
+})

--- a/src/features/toolbar/top-bar.test.tsx
+++ b/src/features/toolbar/top-bar.test.tsx
@@ -13,6 +13,7 @@ function renderTopBar(overrides: Partial<Parameters<typeof TopBar>[0]> = {}) {
     onUndo: vi.fn(),
     onRedo: vi.fn(),
     onClear: vi.fn(),
+    onExport: vi.fn(),
     ...overrides,
   }
   render(

--- a/src/features/toolbar/top-bar.test.tsx
+++ b/src/features/toolbar/top-bar.test.tsx
@@ -58,4 +58,16 @@ describe("TopBar", () => {
     expect(props.onClear).toHaveBeenCalledOnce()
     expect(dialog).not.toBeInTheDocument()
   })
+
+  it("exports only when the canvas contains a drawing", async () => {
+    const user = userEvent.setup()
+    const props = renderTopBar()
+    const exportButton = screen.getByRole("button", {
+      name: "Exporter en PNG",
+    })
+
+    expect(exportButton).toHaveAttribute("data-gesture-control")
+    await user.click(exportButton)
+    expect(props.onExport).toHaveBeenCalledOnce()
+  })
 })

--- a/src/features/toolbar/top-bar.tsx
+++ b/src/features/toolbar/top-bar.tsx
@@ -1,11 +1,42 @@
-import { Download, Redo2, Undo2 } from "lucide-react"
+import { useState } from "react"
 
+import { Download, Redo2, Trash2, Undo2 } from "lucide-react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { ToolButton } from "@/features/toolbar/tool-button"
 
-export function TopBar() {
+type TopBarProps = {
+  canUndo: boolean
+  canRedo: boolean
+  canClear: boolean
+  onUndo: () => void
+  onRedo: () => void
+  onClear: () => void
+}
+
+export function TopBar({
+  canUndo,
+  canRedo,
+  canClear,
+  onUndo,
+  onRedo,
+  onClear,
+}: TopBarProps) {
+  const [clearOpen, setClearOpen] = useState(false)
+
   return (
     <header className="border-border bg-background flex h-16 items-center border-b px-4">
       <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -30,21 +61,59 @@ export function TopBar() {
         className="flex items-center gap-1"
       >
         <ToolButton
-          label="Annuler — bientôt disponible"
+          label="Annuler"
           shortcut="Ctrl Z"
           variant="ghost"
-          disabled
+          disabled={!canUndo}
+          onClick={onUndo}
         >
           <Undo2 aria-hidden="true" />
         </ToolButton>
         <ToolButton
-          label="Rétablir — bientôt disponible"
+          label="Rétablir"
           shortcut="Ctrl Y"
           variant="ghost"
-          disabled
+          disabled={!canRedo}
+          onClick={onRedo}
         >
           <Redo2 aria-hidden="true" />
         </ToolButton>
+        <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+          <AlertDialogTrigger
+            render={
+              <ToolButton
+                label="Effacer la toile"
+                variant="ghost"
+                disabled={!canClear}
+              >
+                <Trash2 aria-hidden="true" />
+              </ToolButton>
+            }
+          />
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Effacer tout le dessin ?</AlertDialogTitle>
+              <AlertDialogDescription>
+                La toile sera vidée. Vous pourrez encore annuler cette action.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel data-gesture-control="">
+                Conserver le dessin
+              </AlertDialogCancel>
+              <AlertDialogAction
+                data-gesture-control=""
+                variant="destructive"
+                onClick={() => {
+                  onClear()
+                  setClearOpen(false)
+                }}
+              >
+                Effacer la toile
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </nav>
 
       <div className="flex flex-1 items-center justify-end gap-3">

--- a/src/features/toolbar/top-bar.tsx
+++ b/src/features/toolbar/top-bar.tsx
@@ -25,6 +25,7 @@ type TopBarProps = {
   onUndo: () => void
   onRedo: () => void
   onClear: () => void
+  onExport: () => void
 }
 
 export function TopBar({
@@ -34,6 +35,7 @@ export function TopBar({
   onUndo,
   onRedo,
   onClear,
+  onExport,
 }: TopBarProps) {
   const [clearOpen, setClearOpen] = useState(false)
 
@@ -124,9 +126,15 @@ export function TopBar({
           Démonstration simulée
         </Badge>
         <Separator orientation="vertical" className="h-6" />
-        <Button className="h-11" variant="outline" disabled>
+        <Button
+          className="h-11"
+          variant="outline"
+          data-gesture-control=""
+          disabled={!canClear}
+          onClick={onExport}
+        >
           <Download aria-hidden="true" data-icon="inline-start" />
-          Exporter bientôt
+          Exporter en PNG
         </Button>
       </div>
     </header>

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 
 import {
   CanvasDrawingController,
+  type DrawingHistoryAvailability,
   type DrawingStyle,
 } from "@/core/drawing/canvas-drawing-controller"
 import type { StrokeAssistanceFeedback } from "@/core/drawing/canvas-drawing-controller"
@@ -13,19 +14,28 @@ import type { DrawingIntention } from "@/core/gestures/drawing-intentions"
 export type DrawingCanvasHandle = {
   handleIntentions(intentions: readonly DrawingIntention[]): void
   revertAssistance(strokeId: string): boolean
+  undo(): void
+  redo(): void
+  clear(): void
 }
 
 type DrawingCanvasProps = {
   assistanceMode: StrokeAssistanceMode
   drawingStyle: DrawingStyle
   onAssistance: (feedback: StrokeAssistanceFeedback) => void
+  onHistoryChange: (availability: DrawingHistoryAvailability) => void
 }
 
 export const DrawingCanvas = forwardRef<
   DrawingCanvasHandle,
   DrawingCanvasProps
 >(function DrawingCanvas(
-  { assistanceMode, drawingStyle, onAssistance }: DrawingCanvasProps,
+  {
+    assistanceMode,
+    drawingStyle,
+    onAssistance,
+    onHistoryChange,
+  }: DrawingCanvasProps,
   ref,
 ) {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -33,12 +43,17 @@ export const DrawingCanvas = forwardRef<
   const interactionRef = useRef<HTMLCanvasElement>(null)
   const controllerRef = useRef<CanvasDrawingController | null>(null)
   const onAssistanceRef = useRef(onAssistance)
+  const onHistoryChangeRef = useRef(onHistoryChange)
   const assistanceModeRef = useRef(assistanceMode)
   const drawingStyleRef = useRef(drawingStyle)
 
   useEffect(() => {
     onAssistanceRef.current = onAssistance
   }, [onAssistance])
+
+  useEffect(() => {
+    onHistoryChangeRef.current = onHistoryChange
+  }, [onHistoryChange])
 
   useEffect(() => {
     assistanceModeRef.current = assistanceMode
@@ -60,6 +75,15 @@ export const DrawingCanvas = forwardRef<
       revertAssistance(strokeId) {
         return controllerRef.current?.revertAssistance(strokeId) ?? false
       },
+      undo() {
+        controllerRef.current?.undo()
+      },
+      redo() {
+        controllerRef.current?.redo()
+      },
+      clear() {
+        controllerRef.current?.clear()
+      },
     }),
     [],
   )
@@ -78,6 +102,9 @@ export const DrawingCanvas = forwardRef<
     controller.setStyle(drawingStyleRef.current)
     controller.setAssistanceListener((feedback) =>
       onAssistanceRef.current(feedback),
+    )
+    controller.setHistoryListener((availability) =>
+      onHistoryChangeRef.current(availability),
     )
     controllerRef.current = controller
     const observer = new ResizeObserver(([entry]) => {

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -1,6 +1,9 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 
-import { CanvasDrawingController } from "@/core/drawing/canvas-drawing-controller"
+import {
+  CanvasDrawingController,
+  type DrawingStyle,
+} from "@/core/drawing/canvas-drawing-controller"
 import type { StrokeAssistanceFeedback } from "@/core/drawing/canvas-drawing-controller"
 import type { StrokeAssistanceMode } from "@/core/drawing/stroke-assistance"
 import { TwoLayerCanvasRenderer } from "@/core/drawing/two-layer-canvas-renderer"
@@ -14,6 +17,7 @@ export type DrawingCanvasHandle = {
 
 type DrawingCanvasProps = {
   assistanceMode: StrokeAssistanceMode
+  drawingStyle: DrawingStyle
   onAssistance: (feedback: StrokeAssistanceFeedback) => void
 }
 
@@ -21,7 +25,7 @@ export const DrawingCanvas = forwardRef<
   DrawingCanvasHandle,
   DrawingCanvasProps
 >(function DrawingCanvas(
-  { assistanceMode, onAssistance }: DrawingCanvasProps,
+  { assistanceMode, drawingStyle, onAssistance }: DrawingCanvasProps,
   ref,
 ) {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -30,6 +34,7 @@ export const DrawingCanvas = forwardRef<
   const controllerRef = useRef<CanvasDrawingController | null>(null)
   const onAssistanceRef = useRef(onAssistance)
   const assistanceModeRef = useRef(assistanceMode)
+  const drawingStyleRef = useRef(drawingStyle)
 
   useEffect(() => {
     onAssistanceRef.current = onAssistance
@@ -39,6 +44,11 @@ export const DrawingCanvas = forwardRef<
     assistanceModeRef.current = assistanceMode
     controllerRef.current?.setAssistanceMode(assistanceMode)
   }, [assistanceMode])
+
+  useEffect(() => {
+    drawingStyleRef.current = drawingStyle
+    controllerRef.current?.setStyle(drawingStyle)
+  }, [drawingStyle])
 
   useImperativeHandle(
     ref,
@@ -65,6 +75,7 @@ export const DrawingCanvas = forwardRef<
     const renderer = new TwoLayerCanvasRenderer(persistent, interaction)
     const controller = new CanvasDrawingController(renderer)
     controller.setAssistanceMode(assistanceModeRef.current)
+    controller.setStyle(drawingStyleRef.current)
     controller.setAssistanceListener((feedback) =>
       onAssistanceRef.current(feedback),
     )

--- a/src/features/workspace/drawing-canvas.tsx
+++ b/src/features/workspace/drawing-canvas.tsx
@@ -17,6 +17,7 @@ export type DrawingCanvasHandle = {
   undo(): void
   redo(): void
   clear(): void
+  exportPng(): Promise<Blob>
 }
 
 type DrawingCanvasProps = {
@@ -83,6 +84,12 @@ export const DrawingCanvas = forwardRef<
       },
       clear() {
         controllerRef.current?.clear()
+      },
+      exportPng() {
+        return (
+          controllerRef.current?.exportPng() ??
+          Promise.reject(new Error("La toile n’est pas encore prête"))
+        )
       },
     }),
     [],

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -41,8 +41,8 @@ describe("WorkspaceShell", () => {
     const user = userEvent.setup()
     renderWorkspace()
 
-    const pen = screen.getByRole("button", { name: "Stylo simulé" })
-    const eraser = screen.getByRole("button", { name: "Gomme simulée" })
+    const pen = screen.getByRole("button", { name: "Stylo" })
+    const eraser = screen.getByRole("button", { name: "Gomme" })
 
     expect(pen).toHaveAttribute("aria-pressed", "true")
     eraser.focus()
@@ -50,9 +50,7 @@ describe("WorkspaceShell", () => {
 
     expect(eraser).toHaveAttribute("aria-pressed", "true")
     expect(pen).toHaveAttribute("aria-pressed", "false")
-    expect(
-      screen.getByText("Gomme sélectionné — simulation"),
-    ).toBeInTheDocument()
+    expect(screen.getByText("Gomme sélectionné, 8 pixels")).toBeInTheDocument()
   })
 
   it("présente la calibration réelle avant le dessin", () => {

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -31,7 +31,7 @@ describe("WorkspaceShell", () => {
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Annuler" })).toBeDisabled()
     expect(
-      screen.getByRole("button", { name: "Exporter bientôt" }),
+      screen.getByRole("button", { name: "Exporter en PNG" }),
     ).toBeDisabled()
   })
 

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -29,9 +29,7 @@ describe("WorkspaceShell", () => {
     expect(
       screen.getByRole("region", { name: "Aperçu caméra" }),
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: "Annuler — bientôt disponible" }),
-    ).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Annuler" })).toBeDisabled()
     expect(
       screen.getByRole("button", { name: "Exporter bientôt" }),
     ).toBeDisabled()

--- a/src/features/workspace/workspace-shell.test.tsx
+++ b/src/features/workspace/workspace-shell.test.tsx
@@ -51,6 +51,32 @@ describe("WorkspaceShell", () => {
     expect(screen.getByText("Gomme sélectionné, 8 pixels")).toBeInTheDocument()
   })
 
+  it("sélectionne les outils par raccourci sauf pendant une saisie", async () => {
+    const user = userEvent.setup()
+    renderWorkspace()
+
+    await user.keyboard("e")
+    expect(screen.getByRole("button", { name: "Gomme" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    await user.keyboard("p")
+    expect(screen.getByRole("button", { name: "Stylo" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+
+    const input = document.createElement("input")
+    document.body.append(input)
+    input.focus()
+    await user.keyboard("e")
+    expect(screen.getByRole("button", { name: "Stylo" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    input.remove()
+  })
+
   it("présente la calibration réelle avant le dessin", () => {
     renderWorkspace()
 

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { Undo2 } from "lucide-react"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import type {
@@ -22,6 +23,7 @@ import type { PinchPhase } from "@/core/gestures/pinch-detector"
 import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
 import { CameraPreview } from "@/features/camera/camera-preview"
+import { createPngFilename, downloadPng } from "@/features/export/png-download"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
 import {
   initialOnboardingState,
@@ -242,6 +244,19 @@ export function WorkspaceShell() {
     drawingRef.current?.clear()
     setLastAssistance(null)
   }, [])
+  const exportPng = useCallback(async () => {
+    try {
+      const blob = await drawingRef.current?.exportPng()
+      if (!blob) throw new Error("Canvas unavailable")
+      const filename = createPngFilename()
+      downloadPng(blob, filename)
+      toast.success("Dessin exporté", { description: filename })
+    } catch {
+      toast.error("L’export PNG a échoué", {
+        description: "Réessayez après avoir terminé votre trait.",
+      })
+    }
+  }, [])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -278,6 +293,7 @@ export function WorkspaceShell() {
         onUndo={undo}
         onRedo={redo}
         onClear={clear}
+        onExport={() => void exportPng()}
       />
       <main className="workspace-main">
         <ToolRail

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import { Undo2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import type { StrokeAssistanceFeedback } from "@/core/drawing/canvas-drawing-controller"
+import type {
+  DrawingStyle,
+  StrokeAssistanceFeedback,
+} from "@/core/drawing/canvas-drawing-controller"
 import type { AssistedPrimitive } from "@/core/drawing/drawing-model"
 import type { StrokeAssistanceMode } from "@/core/drawing/stroke-assistance"
 import type { GestureKind } from "@/core/gestures/gesture-classifier"
@@ -31,7 +34,13 @@ import {
   resetOnboardingCompletion,
   saveOnboardingCompletion,
 } from "@/features/onboarding/onboarding-persistence"
-import { ToolRail, type DrawingTool } from "@/features/toolbar/tool-rail"
+import { findGestureControlAtPoint } from "@/features/toolbar/gesture-control-hit-test"
+import {
+  drawingColors,
+  type DrawingColor,
+  type DrawingTool,
+} from "@/features/toolbar/drawing-tools"
+import { ToolRail } from "@/features/toolbar/tool-rail"
 import { TopBar } from "@/features/toolbar/top-bar"
 import {
   DrawingCanvas,
@@ -62,6 +71,8 @@ export function WorkspaceShell() {
       : initialOnboardingState,
   )
   const [activeTool, setActiveTool] = useState<DrawingTool>("pen")
+  const [color, setColor] = useState<DrawingColor>(drawingColors[0].value)
+  const [thickness, setThickness] = useState(8)
   const [assistanceMode, setAssistanceMode] =
     useState<StrokeAssistanceMode>("stabilized")
   const [lastAssistance, setLastAssistance] =
@@ -76,6 +87,17 @@ export function WorkspaceShell() {
     initialGestureMachineState,
   )
   const onboardingStateRef = useRef<OnboardingState>(initialState)
+  const previousPinchPhaseRef = useRef<PinchPhase>("released")
+  const gestureControlActiveRef = useRef(false)
+
+  const drawingStyle = useMemo<DrawingStyle>(
+    () => ({
+      tool: activeTool === "eraser" ? "eraser" : "pen",
+      color,
+      width: thickness / 1000,
+    }),
+    [activeTool, color, thickness],
+  )
 
   const restartOnboarding = useCallback(() => {
     onboardingStateRef.current = initialOnboardingState
@@ -118,16 +140,50 @@ export function WorkspaceShell() {
         ? mapMirroredCameraPointToCanvas(filtered.point, bounds)
         : null
       if (onboarding.step < 3) return
+      const pinchBecameActive =
+        pinchPhase === "active" && previousPinchPhaseRef.current !== "active"
+      previousPinchPhaseRef.current = pinchPhase
+      if (
+        mapped &&
+        filtered.reliable &&
+        pinchBecameActive &&
+        !gestureControlActiveRef.current
+      ) {
+        const control = findGestureControlAtPoint(mapped)
+        if (control) {
+          control.click()
+          gestureControlActiveRef.current = true
+        }
+      }
+      if (gestureControlActiveRef.current) {
+        drawingRef.current?.handleIntentions([
+          ...(mapped
+            ? ([
+                {
+                  version: 1,
+                  type: "POINTER_MOVE",
+                  point: mapped,
+                  timestampMs: result.timestampMs,
+                },
+              ] as const)
+            : []),
+          { version: 1, type: "PAUSE", timestampMs: result.timestampMs },
+        ])
+        if (pinchPhase === "released") gestureControlActiveRef.current = false
+        return
+      }
       const drawingGesture: GestureKind =
         quality === "lost"
           ? "tracking-lost"
           : quality === "uncertain"
             ? "uncertain"
-            : pinchPhase !== "released"
-              ? "pinch"
-              : gesture === "fist"
-                ? "fist"
-                : "open-hand"
+            : activeTool === "pointer"
+              ? "open-hand"
+              : pinchPhase !== "released"
+                ? "pinch"
+                : gesture === "fist"
+                  ? "fist"
+                  : "open-hand"
       const transition = transitionGestureState(gestureStateRef.current, {
         gesture: drawingGesture,
         point: filtered.reliable ? mapped : null,
@@ -145,7 +201,7 @@ export function WorkspaceShell() {
       }
       drawingRef.current?.handleIntentions(transition.intentions)
     },
-    [onboardingStep],
+    [activeTool, onboardingStep],
   )
 
   const changeAssistanceMode = useCallback((mode: StrokeAssistanceMode) => {
@@ -167,7 +223,14 @@ export function WorkspaceShell() {
       </a>
       <TopBar />
       <main className="workspace-main">
-        <ToolRail activeTool={activeTool} onToolChange={setActiveTool} />
+        <ToolRail
+          activeTool={activeTool}
+          color={color}
+          thickness={thickness}
+          onToolChange={setActiveTool}
+          onColorChange={setColor}
+          onThicknessChange={setThickness}
+        />
 
         <section
           ref={stageRef}
@@ -179,10 +242,11 @@ export function WorkspaceShell() {
           <DrawingCanvas
             ref={drawingRef}
             assistanceMode={assistanceMode}
+            drawingStyle={drawingStyle}
             onAssistance={setLastAssistance}
           />
           <div className="sr-only" aria-live="polite">
-            {toolNames[activeTool]} sélectionné — simulation
+            {toolNames[activeTool]} sélectionné, {thickness} pixels
           </div>
           <CameraPreview
             calibrating={onboardingStep < 3}

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { Undo2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import type {
+  DrawingHistoryAvailability,
   DrawingStyle,
   StrokeAssistanceFeedback,
 } from "@/core/drawing/canvas-drawing-controller"
@@ -64,6 +65,22 @@ const primitiveNames: Record<AssistedPrimitive, string> = {
   rectangle: "Rectangle",
 }
 
+const emptyHistoryAvailability: DrawingHistoryAvailability = {
+  canUndo: false,
+  canRedo: false,
+  canClear: false,
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  return (
+    target instanceof HTMLElement &&
+    (target.isContentEditable ||
+      target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.tagName === "SELECT")
+  )
+}
+
 export function WorkspaceShell() {
   const [initialState] = useState<OnboardingState>(() =>
     loadOnboardingCompletion()
@@ -77,6 +94,9 @@ export function WorkspaceShell() {
     useState<StrokeAssistanceMode>("stabilized")
   const [lastAssistance, setLastAssistance] =
     useState<StrokeAssistanceFeedback | null>(null)
+  const [historyAvailability, setHistoryAvailability] = useState(
+    emptyHistoryAvailability,
+  )
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(
     initialState.step,
   )
@@ -216,12 +236,49 @@ export function WorkspaceShell() {
     }
   }, [lastAssistance])
 
+  const undo = useCallback(() => drawingRef.current?.undo(), [])
+  const redo = useCallback(() => drawingRef.current?.redo(), [])
+  const clear = useCallback(() => {
+    drawingRef.current?.clear()
+    setLastAssistance(null)
+  }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target) || !(event.ctrlKey || event.metaKey)) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+      if (key === "z") {
+        const canApply = event.shiftKey
+          ? historyAvailability.canRedo
+          : historyAvailability.canUndo
+        if (!canApply) return
+        event.preventDefault()
+        if (event.shiftKey) redo()
+        else undo()
+      } else if (key === "y" && historyAvailability.canRedo) {
+        event.preventDefault()
+        redo()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [historyAvailability, redo, undo])
+
   return (
     <div className="workspace-shell">
       <a className="skip-link" href="#drawing-canvas">
         Aller à la toile
       </a>
-      <TopBar />
+      <TopBar
+        {...historyAvailability}
+        onUndo={undo}
+        onRedo={redo}
+        onClear={clear}
+      />
       <main className="workspace-main">
         <ToolRail
           activeTool={activeTool}
@@ -244,6 +301,7 @@ export function WorkspaceShell() {
             assistanceMode={assistanceMode}
             drawingStyle={drawingStyle}
             onAssistance={setLastAssistance}
+            onHistoryChange={setHistoryAvailability}
           />
           <div className="sr-only" aria-live="polite">
             {toolNames[activeTool]} sélectionné, {thickness} pixels

--- a/src/features/workspace/workspace-shell.tsx
+++ b/src/features/workspace/workspace-shell.tsx
@@ -22,7 +22,10 @@ import { selectGesturePointer } from "@/core/gestures/gesture-pointer"
 import type { PinchPhase } from "@/core/gestures/pinch-detector"
 import { mapMirroredCameraPointToCanvas } from "@/core/geometry/coordinate-mapping"
 
-import { CameraPreview } from "@/features/camera/camera-preview"
+import {
+  CameraPreview,
+  type CameraPreviewHandle,
+} from "@/features/camera/camera-preview"
 import { createPngFilename, downloadPng } from "@/features/export/png-download"
 import { GestureCoach } from "@/features/onboarding/gesture-coach"
 import {
@@ -104,6 +107,7 @@ export function WorkspaceShell() {
   )
   const stageRef = useRef<HTMLElement>(null)
   const drawingRef = useRef<DrawingCanvasHandle>(null)
+  const cameraRef = useRef<CameraPreviewHandle>(null)
   const pointerFilterRef = useRef(new PointerMotionFilter())
   const gestureStateRef = useRef<GestureMachineState>(
     initialGestureMachineState,
@@ -260,12 +264,10 @@ export function WorkspaceShell() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (isEditableTarget(event.target) || !(event.ctrlKey || event.metaKey)) {
-        return
-      }
-
+      if (isEditableTarget(event.target)) return
       const key = event.key.toLowerCase()
-      if (key === "z") {
+      const withCommand = event.ctrlKey || event.metaKey
+      if (withCommand && key === "z") {
         const canApply = event.shiftKey
           ? historyAvailability.canRedo
           : historyAvailability.canUndo
@@ -273,9 +275,23 @@ export function WorkspaceShell() {
         event.preventDefault()
         if (event.shiftKey) redo()
         else undo()
-      } else if (key === "y" && historyAvailability.canRedo) {
+      } else if (withCommand && key === "y" && historyAvailability.canRedo) {
         event.preventDefault()
         redo()
+      } else if (!withCommand && !event.altKey && key === "p") {
+        event.preventDefault()
+        setActiveTool("pen")
+      } else if (!withCommand && !event.altKey && key === "e") {
+        event.preventDefault()
+        setActiveTool("eraser")
+      } else if (
+        !withCommand &&
+        !event.altKey &&
+        event.code === "Space" &&
+        !(event.target instanceof HTMLButtonElement)
+      ) {
+        event.preventDefault()
+        cameraRef.current?.togglePause()
       }
     }
 
@@ -323,6 +339,7 @@ export function WorkspaceShell() {
             {toolNames[activeTool]} sélectionné, {thickness} pixels
           </div>
           <CameraPreview
+            ref={cameraRef}
             calibrating={onboardingStep < 3}
             onGestureFrame={handleGestureFrame}
           />

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -59,6 +59,15 @@
   background: var(--border);
 }
 
+.drawing-thickness-preview {
+  display: block;
+  height: 0.125rem;
+  min-width: 0.25rem;
+  max-width: 1.375rem;
+  background: currentColor;
+  border-radius: 999px;
+}
+
 .camera-preview {
   position: absolute;
   top: var(--space-xl);


### PR DESCRIPTION
## Objectif

Livrer le lot 8 de `IMPLEMENTATION_PLAN.md` : outils complets, historique accessible, raccourcis et export PNG haute résolution.

## Changements

- active le stylo, la gomme, quatre couleurs et l’épaisseur du trait à la souris, au clavier et par pincement gestuel
- expose annuler, rétablir et effacer avec confirmation Base UI, états désactivés et raccourcis d’historique
- exporte la toile avec un fond blanc à la résolution physique du Canvas et un nom horodaté
- ajoute les raccourcis P, E et Espace sans interférer avec les champs saisissables
- affiche les résultats d’export avec Sonner et couvre les comportements sensibles par des tests

## Preuves

- [x] `pnpm validate`
- [x] Tests supplémentaires prescrits par le lot
- [x] Vérification manuelle avec webcam réelle
- [x] Aucun secret, asset généré ou fichier de build ajouté
- [x] Documentation et ADR mis à jour si une décision a changé

Résultat local : 31 fichiers de tests, 188 tests réussis, build Vite réussi.

Validation manuelle webcam réelle réussie le 25 août 2026 : dessin, formes assistées, couleurs, commandes et export PNG sur fond blanc vérifiés.

## Promotion en production

Sans objet : PR vers `dev`.

## Risques et rollback

Le risque principal concerne les différences de téléchargement Canvas et de raccourcis caméra selon le navigateur. Le rollback consiste à rebaser la PR hors de `dev`; les cinq commits restent atomiques et réversibles indépendamment.
